### PR TITLE
Feature/zoom force

### DIFF
--- a/R/simpleNetwork.R
+++ b/R/simpleNetwork.R
@@ -60,7 +60,7 @@ simpleNetwork <- function(Data,
                           nodeColour = "#3182bd",
                           nodeClickColour = "#E34A33",
                           textColour = "#3182bd",
-                          opacity = 0.6
+                          opacity = 0.6,
                           zoom = F)
 {
   # validate input


### PR DESCRIPTION
Add zoom to `simpleNetwork` and `forceNetwork` using the parameter `zoom = T|F`.  I did not roxygenize or add example in the docs.  Happy to do so if you like.