### PR TITLE
forceNetwork and treeNetwork examples: getURL() needs followlocation=TRUE

### DIFF
--- a/R/forceNetwork.R
+++ b/R/forceNetwork.R
@@ -55,7 +55,7 @@
 #' #### JSON Data Example
 #' # Load data JSON formated data into two R data frames
 #' library(RCurl)
-#' MisJson <- getURL("http://bit.ly/1cc3anB")
+#' MisJson <- getURL("http://bit.ly/1cc3anB", followlocation=TRUE)
 #' MisLinks <- JSONtoDF(jsonStr = MisJson, array = "links")
 #' MisNodes <- JSONtoDF(jsonStr = MisJson, array = "nodes")
 #'

--- a/R/treeNetwork.R
+++ b/R/treeNetwork.R
@@ -25,7 +25,7 @@
 #' #### Create tree from JSON formatted data
 #' ## Download JSON data
 #' library(RCurl)
-#' Flare <- getURL("http://bit.ly/1uNNAbu")
+#' Flare <- getURL("http://bit.ly/1uNNAbu", followlocation=TRUE)
 #'
 #' ## Convert to list format
 #' Flare <- rjson::fromJSON(Flare)

--- a/man/forceNetwork.Rd
+++ b/man/forceNetwork.Rd
@@ -89,7 +89,7 @@ forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
 #### JSON Data Example
 # Load data JSON formated data into two R data frames
 library(RCurl)
-MisJson <- getURL("http://bit.ly/1cc3anB")
+MisJson <- getURL("http://bit.ly/1cc3anB", followlocation=TRUE)
 MisLinks <- JSONtoDF(jsonStr = MisJson, array = "links")
 MisNodes <- JSONtoDF(jsonStr = MisJson, array = "nodes")
 

--- a/man/treeNetwork.Rd
+++ b/man/treeNetwork.Rd
@@ -51,7 +51,7 @@ Create Reingold-Tilford Tree network diagrams.
 #### Create tree from JSON formatted data
 ## Download JSON data
 library(RCurl)
-Flare <- getURL("http://bit.ly/1uNNAbu")
+Flare <- getURL("http://bit.ly/1uNNAbu", followlocation=TRUE)
 
 ## Convert to list format
 Flare <- rjson::fromJSON(Flare)


### PR DESCRIPTION
 - On my system at least, with bit.ly links, I need to use
   `followlocation=TRUE` within `getURL()`.