### PR TITLE
Tweaks for sankeyNetwork

### DIFF
--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -16,6 +16,7 @@
 #' frame for how far away the nodes are from one another.
 #' @param NodeID character string specifying the node IDs in the \code{Nodes}
 #' data frame.
+#' @param units character string describing physical units (if any) for Value
 #' @param height numeric height for the network graph's frame area in pixels.
 #' @param width numeric width for the network graph's frame area in pixels.
 #' @param colourScale character string specifying the categorical colour
@@ -39,7 +40,7 @@
 #' # Plot
 #' sankeyNetwork(Links = EngLinks, Nodes = EngNodes, Source = "source",
 #'              Target = "target", Value = "value", NodeID = "name",
-#               fontsize = 12, nodeWidth = 30)
+#               units = "TWh", fontsize = 12, nodeWidth = 30)
 #' }
 #' @source
 #' D3.js was created by Michael Bostock. See \url{http://d3js.org/} and, more
@@ -47,8 +48,8 @@
 #'
 #' @export
 
-sankeyNetwork <- function(Links, Nodes, Source, Target, Value, NodeID,
-    height = NULL, width = NULL, colourScale = "d3.scale.category20()",
+sankeyNetwork <- function(Links, Nodes, Source, Target, Value, NodeID, 
+    units = "", height = NULL, width = NULL, colourScale = "d3.scale.category20()",
     fontsize = 7, nodeWidth = 15, nodePadding = 10)
 {
     # Subset data frames for network graph
@@ -75,7 +76,8 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value, NodeID,
         colourScale = colourScale,
         fontsize = fontsize,
         nodeWidth = nodeWidth,
-        nodePadding = nodePadding
+        nodePadding = nodePadding,
+        units = units
     )
 
     # create widget

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -22,7 +22,8 @@
 #' @param colourScale character string specifying the categorical colour
 #' scale for the nodes. See
 #' \url{https://github.com/mbostock/d3/wiki/Ordinal-Scales}.
-#' @param fontsize numeric font size in pixels for the node text labels.
+#' @param fontSize numeric font size in pixels for the node text labels.
+#' @param fontFamily font family for the node text labels.
 #' @param nodeWidth numeric width of each node.
 #' @param nodePadding numeric essentially influences the width height.
 #'
@@ -40,7 +41,7 @@
 #' # Plot
 #' sankeyNetwork(Links = EngLinks, Nodes = EngNodes, Source = "source",
 #'              Target = "target", Value = "value", NodeID = "name",
-#               units = "TWh", fontsize = 12, nodeWidth = 30)
+#               units = "TWh", fontSize = 12, nodeWidth = 30)
 #' }
 #' @source
 #' D3.js was created by Michael Bostock. See \url{http://d3js.org/} and, more
@@ -50,7 +51,7 @@
 
 sankeyNetwork <- function(Links, Nodes, Source, Target, Value, NodeID, 
     units = "", height = NULL, width = NULL, colourScale = "d3.scale.category20()",
-    fontsize = 7, nodeWidth = 15, nodePadding = 10)
+    fontSize = 7, fontFamily = NULL, nodeWidth = 15, nodePadding = 10)
 {
     # Subset data frames for network graph
     if (class(Links) != "data.frame"){
@@ -74,7 +75,8 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value, NodeID,
     options = list(
         NodeID = NodeID,
         colourScale = colourScale,
-        fontsize = fontsize,
+        fontSize = fontSize,
+        fontFamily = fontFamily,
         nodeWidth = nodeWidth,
         nodePadding = nodePadding,
         units = units

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -98,7 +98,7 @@ HTMLWidgets.widget({
 
         link.append("title")
             .text(function(d) { return d.source.name + d.target.name +
-                "\\n" + format(d.value); });
+                "\n" + format(d.value); });
 
         node.append("rect")
             .attr("height", function(d) { return d.dy; })
@@ -109,7 +109,7 @@ HTMLWidgets.widget({
             .style("opacity", 0.9)
             .style("cursor", "move")
             .append("title")
-            .text(function(d) { return d.name + "\\n" + format(d.value); });
+            .text(function(d) { return d.name + "\n" + format(d.value); });
 
         node.append("svg:text")
             .attr("x", -6)

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -118,7 +118,7 @@ HTMLWidgets.widget({
             .attr("text-anchor", "end")
             .attr("transform", null)
             .text(function(d) { return d.name; })
-            .style("font", options.fontsize + "px serif")
+            .style("font", options.fontsize + "px")
             .filter(function(d) { return d.x < width / 2; })
             .attr("x", 6 + sankey.nodeWidth())
             .attr("text-anchor", "start");

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -97,7 +97,7 @@ HTMLWidgets.widget({
 
 
         link.append("title")
-            .text(function(d) { return d.source.name + d.target.name +
+            .text(function(d) { return d.source.name + " \u2192 " + d.target.name +
                 "\n" + format(d.value); });
 
         node.append("rect")

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -119,7 +119,8 @@ HTMLWidgets.widget({
             .attr("text-anchor", "end")
             .attr("transform", null)
             .text(function(d) { return d.name; })
-            .style("font", options.fontsize + "px")
+            .style("font", options.fontSize + "px")
+            .style("font-family", options.fontFamily ? options.fontFamily : "inherit")
             .filter(function(d) { return d.x < width / 2; })
             .attr("x", 6 + sankey.nodeWidth())
             .attr("text-anchor", "start");

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -95,7 +95,7 @@ HTMLWidgets.widget({
             .on("dragstart", function() { this.parentNode.appendChild(this); })
             .on("drag", dragmove));
 
-
+        // note: u2192 is right-arrow
         link.append("title")
             .text(function(d) { return d.source.name + " \u2192 " + d.target.name +
                 "\n" + format(d.value); });

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -98,7 +98,7 @@ HTMLWidgets.widget({
         // note: u2192 is right-arrow
         link.append("title")
             .text(function(d) { return d.source.name + " \u2192 " + d.target.name +
-                "\n" + format(d.value); });
+                "\n" + format(d.value) + " " + options.units; });
 
         node.append("rect")
             .attr("height", function(d) { return d.dy; })
@@ -109,7 +109,8 @@ HTMLWidgets.widget({
             .style("opacity", 0.9)
             .style("cursor", "move")
             .append("title")
-            .text(function(d) { return d.name + "\n" + format(d.value); });
+            .text(function(d) { return d.name + "\n" + format(d.value) + 
+                " " + options.units; });
 
         node.append("svg:text")
             .attr("x", -6)


### PR DESCRIPTION
I had this lying around to address #15 - so I thought I would throw it over the wall as a PR.

There are a few things done for this PR:

1. Removes the font specification, to use the d3 default
2. Adjusts number of backslashes for the newline in the tooltip
3. Puts in a right arrow in the tooltip, between the source and the target
4. Adds an option for physical units to be displayed the tooltip.