### PR TITLE
New options for simpleNetwork plots

### DIFF
--- a/R/simpleNetwork.R
+++ b/R/simpleNetwork.R
@@ -40,7 +40,8 @@
 #'  \code{opacity} parameters may be a single character string specifying values
 #'  for all nodes and links, or they may be vectors of the same length as the
 #'  number of nodes or links. The total number of unique nodes and their
-#'  order is given by \code{unique(Reduce(c,t(Data)))} (see below for an example).
+#'  plot order is given by \code{unique(Reduce(c,t(Data)))} (see below for an example).
+#'  The links are ordered by the rows of \code{Data}.
 #'  Alternatively, consider \code{forceNetwork} for additional output
 #'  options.
 #'
@@ -55,8 +56,15 @@
 #'
 #' # Alter the colors of each node.
 #' nodes <- unique(Reduce(c, t(NetworkData))) # Graph nodes in order
-#' # Note use of substring to remove alpha level from colors.
+#' # (Note use of substring to remove alpha level from colors)
 #' simpleNetwork(NetworkData, nodeColour=substr(rainbow(length(nodes)),1,7))
+#'
+#' # Color the links independently too
+#' link_colours <- c(rep("#0000ff",4), rep("#00ff00",2), rep("#ff0000",2), "#000000")
+#' simpleNetwork(NetworkData, linkColour=link_colours)
+#'
+#' # Display as a directed graph
+#' simpleNetwork(NetworkData, linkColour=link_colours, directed=TRUE)
 #'
 #' @source D3.js was created by Michael Bostock. See \url{http://d3js.org/} and,
 #'   more specifically for directed networks

--- a/R/simpleNetwork.R
+++ b/R/simpleNetwork.R
@@ -33,7 +33,7 @@
 #' @param opacity numeric value of the proportion opaque you would like the
 #'   graph elements to be.
 #'
-#' @note The \code{linkColour}, \code{nodeColour}, \code{textColour}, and
+#' @note The \code{linkColour}, \code{nodeColour}, \code{textColour}, \code{nodeClickColour}, and
 #'  \code{opacity} parameters may be a single character string specifying values
 #'  for all nodes and links, or they may be vectors of the same length as the
 #'  number of nodes or links. The total number of unique nodes and their

--- a/R/simpleNetwork.R
+++ b/R/simpleNetwork.R
@@ -27,17 +27,22 @@
 #'   circles to be. Multiple formats supported (e.g. hexadecimal).
 #' @param nodeClickColour character string specifying the colour you want the
 #'   node circles to be when they are clicked. Also changes the colour of the
-#'   text. Multiple formats supported (e.g. hexadecimal).
+#'   text. Multiple formats supported (e.g. hexadecimal). Set to \code{NULL}
+#'   to not change color when clicked.
 #' @param textColour character string specifying the colour you want the text to
 #'   be before they are clicked. Multiple formats supported (e.g. hexadecimal).
 #' @param opacity numeric value of the proportion opaque you would like the
 #'   graph elements to be.
+#' @param directed TRUE draws a directed graph with arrows, FALSE draws
+#'   an undirected graph (the default).
 #'
-#' @note The \code{linkColour}, \code{nodeColour}, \code{textColour}, \code{nodeClickColour}, and
+#' @note The \code{linkColour}, \code{nodeColour}, \code{textColour}, and
 #'  \code{opacity} parameters may be a single character string specifying values
 #'  for all nodes and links, or they may be vectors of the same length as the
 #'  number of nodes or links. The total number of unique nodes and their
-#'  order is given by \code{unique(Reduce(c,t(Data)))}.
+#'  order is given by \code{unique(Reduce(c,t(Data)))} (see below for an example).
+#'  Alternatively, consider \code{forceNetwork} for additional output
+#'  options.
 #'
 #' @examples
 #' # Fake data
@@ -47,6 +52,11 @@
 #'
 #' # Create graph
 #' simpleNetwork(NetworkData)
+#'
+#' # Alter the colors of each node.
+#' nodes <- unique(Reduce(c, t(NetworkData))) # Graph nodes in order
+#' # Note use of substring to remove alpha level from colors.
+#' simpleNetwork(NetworkData, nodeColour=substr(rainbow(length(nodes)),1,7))
 #'
 #' @source D3.js was created by Michael Bostock. See \url{http://d3js.org/} and,
 #'   more specifically for directed networks
@@ -65,7 +75,8 @@ simpleNetwork <- function(Data,
                           nodeColour = "#3182bd",
                           nodeClickColour = "#E34A33",
                           textColour = "#3182bd",
-                          opacity = 0.6)
+                          opacity = 0.6,
+                          directed = FALSE)
 {
   # validate input
     if (!is.data.frame(Data))
@@ -87,7 +98,8 @@ simpleNetwork <- function(Data,
         nodeColour = nodeColour,
         nodeClickColour = nodeClickColour,
         textColour = textColour,
-        opacity = opacity
+        opacity = opacity,
+        directed = directed
     )
 
     # create widget

--- a/R/simpleNetwork.R
+++ b/R/simpleNetwork.R
@@ -36,7 +36,8 @@
 #' @note The \code{linkColour}, \code{nodeColour}, \code{textColour}, and
 #'  \code{opacity} parameters may be a single character string specifying values
 #'  for all nodes and links, or they may be vectors of the same length as the
-#'  number of rows in \code{Data} specifying a value per row.
+#'  number of nodes or links. The total number of unique nodes and their
+#'  order is given by \code{unique(Reduce(c,t(Data)))}.
 #'
 #' @examples
 #' # Fake data

--- a/R/simpleNetwork.R
+++ b/R/simpleNetwork.R
@@ -33,6 +33,11 @@
 #' @param opacity numeric value of the proportion opaque you would like the
 #'   graph elements to be.
 #'
+#' @note The \code{linkColour}, \code{nodeColour}, \code{textColour}, and
+#'  \code{opacity} parameters may be a single character string specifying values
+#'  for all nodes and links, or they may be vectors of the same length as the
+#'  number of rows in \code{Data} specifying a value per row.
+#'
 #' @examples
 #' # Fake data
 #' Source <- c("A", "A", "A", "A", "B", "B", "C", "C", "D")

--- a/inst/htmlwidgets/simpleNetwork.js
+++ b/inst/htmlwidgets/simpleNetwork.js
@@ -60,7 +60,8 @@ HTMLWidgets.widget({
       .style("stroke", function(d,i)
         { if(Array.isArray(x.options.linkColour)) return x.options.linkColour[i];
           return x.options.linkColour;})
-      .style("opacity", function(d,i)
+      .style("opacity",
+ function(d,i)
         { if(Array.isArray(x.options.opacity)) return x.options.opacity[i];
           return x.options.opacity;})
       .style("stroke-width", "1.5px");
@@ -92,7 +93,8 @@ HTMLWidgets.widget({
       .attr("x", 12)
       .attr("dy", ".35em")
       .style("font", x.options.fontSize + "px serif")
-      .style("fill", function(d,i)
+      .style("fill",
+ function(d,i)
         { if(Array.isArray(x.options.textColour)) return x.options.textColour[i];
           return x.options.textColour;})
       .style("opacity", function(d,i)
@@ -134,11 +136,15 @@ HTMLWidgets.widget({
         .attr("x", 22)
         .style("stroke-width", ".5px")
         .style("opacity", 1)
-        .style("fill", x.options.nodeClickColour)
+        .style("fill", function(d,i)
+        { if(Array.isArray(x.options.nodeClickColour)) return x.options.nodeClickColour[i];
+          return x.options.nodeClickColour;})
         .style("font", x.options.clickTextSize + "px serif");
       d3.select(this).select("circle").transition()
         .duration(750)
-        .style("fill", x.options.nodeClickColour)
+        .style("fill", function(d,i)
+        { if(Array.isArray(x.options.nodeClickColour)) return x.options.nodeClickColour[i];
+          return x.options.nodeClickColour;})
         .attr("r", 16)
     }
 
@@ -147,14 +153,20 @@ HTMLWidgets.widget({
       d3.select(this).select("circle").transition()
         .duration(750)
         .attr("r", 6)
-        .style("fill", x.options.nodeClickColour);
+        .style("fill", function(d,i)
+        { if(Array.isArray(x.options.nodeClickColour)) return x.options.nodeClickColour[i];
+          return x.options.nodeClickColour;});
         d3.select(this).select("text").transition()
         .duration(750)
         .attr("x", 12)
         .style("stroke", "none")
-        .style("fill", x.options.nodeClickColour)
+        .style("fill", function(d,i)
+        { if(Array.isArray(x.options.nodeClickColour)) return x.options.nodeClickColour[i];
+          return x.options.nodeClickColour;})
         .style("stroke", "none")
-        .style("opacity", x.options.opacity)
+        .style("opacity", function(d,i)
+        { if(Array.isArray(x.options.opacity)) return x.options.opacity[i];
+          return x.options.opacity;})
         .style("font", x.options.fontSize + "px serif");
     }
   },

--- a/inst/htmlwidgets/simpleNetwork.js
+++ b/inst/htmlwidgets/simpleNetwork.js
@@ -60,8 +60,7 @@ HTMLWidgets.widget({
       .style("stroke", function(d,i)
         { if(Array.isArray(x.options.linkColour)) return x.options.linkColour[i];
           return x.options.linkColour;})
-      .style("opacity",
- function(d,i)
+      .style("opacity", function(d,i)
         { if(Array.isArray(x.options.opacity)) return x.options.opacity[i];
           return x.options.opacity;})
       .style("stroke-width", "1.5px");
@@ -131,42 +130,34 @@ HTMLWidgets.widget({
 
     // click event handler
     function click() {
+      if(x.options.nodeClickColour === null) return;
       d3.select(this).select("text").transition()
         .duration(750)
         .attr("x", 22)
         .style("stroke-width", ".5px")
         .style("opacity", 1)
-        .style("fill", function(d,i)
-        { if(Array.isArray(x.options.nodeClickColour)) return x.options.nodeClickColour[i];
-          return x.options.nodeClickColour;})
+        .style("fill", x.options.nodeClickColour)
         .style("font", x.options.clickTextSize + "px serif");
       d3.select(this).select("circle").transition()
         .duration(750)
-        .style("fill", function(d,i)
-        { if(Array.isArray(x.options.nodeClickColour)) return x.options.nodeClickColour[i];
-          return x.options.nodeClickColour;})
+        .style("fill", x.options.nodeClickColour)
         .attr("r", 16)
     }
 
     // double-click event handler
     function dblclick() {
+      if(x.options.nodeClickColour === null) return;
       d3.select(this).select("circle").transition()
         .duration(750)
         .attr("r", 6)
-        .style("fill", function(d,i)
-        { if(Array.isArray(x.options.nodeClickColour)) return x.options.nodeClickColour[i];
-          return x.options.nodeClickColour;});
-        d3.select(this).select("text").transition()
+        .style("fill", x.options.nodeClickColour);
+      d3.select(this).select("text").transition()
         .duration(750)
         .attr("x", 12)
         .style("stroke", "none")
-        .style("fill", function(d,i)
-        { if(Array.isArray(x.options.nodeClickColour)) return x.options.nodeClickColour[i];
-          return x.options.nodeClickColour;})
+        .style("fill", x.options.nodeClickColour)
         .style("stroke", "none")
-        .style("opacity", function(d,i)
-        { if(Array.isArray(x.options.opacity)) return x.options.opacity[i];
-          return x.options.opacity;})
+        .style("opacity", 1)
         .style("font", x.options.fontSize + "px serif");
     }
   },

--- a/inst/htmlwidgets/simpleNetwork.js
+++ b/inst/htmlwidgets/simpleNetwork.js
@@ -168,6 +168,9 @@ HTMLWidgets.widget({
       d3.select(this).select("circle").transition()
       .duration(750)
       .attr("r", 16);
+      d3.select(this).select("text").transition()
+      .duration(550)
+      .style("font", 2 * x.options.fontSize + "px serif");
     }
 
     // mouseout event handler
@@ -175,6 +178,9 @@ HTMLWidgets.widget({
       d3.select(this).select("circle").transition()
       .duration(750)
       .attr("r", 8);
+      d3.select(this).select("text").transition()
+      .duration(550)
+      .style("font", x.options.fontSize + "px serif");
     }
 
     // click event handler

--- a/inst/htmlwidgets/simpleNetwork.js
+++ b/inst/htmlwidgets/simpleNetwork.js
@@ -57,8 +57,12 @@ HTMLWidgets.widget({
     var link = svg.selectAll(".link")
       .data(force.links())
       .enter().append("line")
-      .style("stroke", x.options.linkColour)
-      .style("opacity", x.options.opacity)
+      .style("stroke", function(d,i)
+        { if(Array.isArray(x.options.linkColour)) return x.options.linkColour[i];
+          return x.options.linkColour;})
+      .style("opacity", function(d,i)
+        { if(Array.isArray(x.options.opacity)) return x.options.opacity[i];
+          return x.options.opacity;})
       .style("stroke-width", "1.5px");
 
     // draw nodes
@@ -74,9 +78,13 @@ HTMLWidgets.widget({
     // node circles
     node.append("circle")
       .attr("r", 8)
-      .style("fill", x.options.nodeColour)
+      .style("fill", function(d,i)
+        { if(Array.isArray(x.options.nodeColour)) return x.options.nodeColour[i];
+          return x.options.nodeColour;})
       .style("stroke", "#fff")
-      .style("opacity", x.options.opacity)
+      .style("opacity", function(d,i)
+        { if(Array.isArray(x.options.opacity)) return x.options.opacity[i];
+          return x.options.opacity;})
       .style("stroke-width", "1.5px");
 
     // node text
@@ -84,8 +92,12 @@ HTMLWidgets.widget({
       .attr("x", 12)
       .attr("dy", ".35em")
       .style("font", x.options.fontSize + "px serif")
-      .style("fill", x.options.textColour)
-      .style("opacity", x.options.opacity)
+      .style("fill", function(d,i)
+        { if(Array.isArray(x.options.textColour)) return x.options.textColour[i];
+          return x.options.textColour;})
+      .style("opacity", function(d,i)
+        { if(Array.isArray(x.options.opacity)) return x.options.opacity[i];
+          return x.options.opacity;})
       .style("pointer-events", "none")
       .text(function(d) { return d.name; });
 

--- a/man/simpleNetwork.Rd
+++ b/man/simpleNetwork.Rd
@@ -71,7 +71,8 @@ The \code{linkColour}, \code{nodeColour}, \code{textColour}, and
  \code{opacity} parameters may be a single character string specifying values
  for all nodes and links, or they may be vectors of the same length as the
  number of nodes or links. The total number of unique nodes and their
- order is given by \code{unique(Reduce(c,t(Data)))} (see below for an example).
+ plot order is given by \code{unique(Reduce(c,t(Data)))} (see below for an example).
+ The links are ordered by the rows of \code{Data}.
  Alternatively, consider \code{forceNetwork} for additional output
  options.
 }
@@ -86,7 +87,14 @@ simpleNetwork(NetworkData)
 
 # Alter the colors of each node.
 nodes <- unique(Reduce(c, t(NetworkData))) # Graph nodes in order
-# Note use of substring to remove alpha level from colors.
+# (Note use of substring to remove alpha level from colors)
 simpleNetwork(NetworkData, nodeColour=substr(rainbow(length(nodes)),1,7))
+
+# Color the links independently too
+link_colours <- c(rep("#0000ff",4), rep("#00ff00",2), rep("#ff0000",2), "#000000")
+simpleNetwork(NetworkData, linkColour=link_colours)
+
+# Display as a directed graph
+simpleNetwork(NetworkData, linkColour=link_colours, directed=TRUE)
 }
 

--- a/man/simpleNetwork.Rd
+++ b/man/simpleNetwork.Rd
@@ -65,7 +65,8 @@ graphs.
 The \code{linkColour}, \code{nodeColour}, \code{textColour}, and
  \code{opacity} parameters may be a single character string specifying values
  for all nodes and links, or they may be vectors of the same length as the
- number of rows in \code{Data} specifying a value per row.
+ number of nodes or links. The total number of unique nodes and their
+ order is given by \code{unique(Reduce(c,t(Data)))}.
 }
 \examples{
 # Fake data

--- a/man/simpleNetwork.Rd
+++ b/man/simpleNetwork.Rd
@@ -12,7 +12,8 @@ D3.js was created by Michael Bostock. See \url{http://d3js.org/} and,
 simpleNetwork(Data, Source = NULL, Target = NULL, height = NULL,
   width = NULL, linkDistance = 50, charge = -200, fontSize = 7,
   linkColour = "#666", nodeColour = "#3182bd",
-  nodeClickColour = "#E34A33", textColour = "#3182bd", opacity = 0.6)
+  nodeClickColour = "#E34A33", textColour = "#3182bd", opacity = 0.6,
+  directed = FALSE)
 }
 \arguments{
 \item{Data}{a data frame object with three columns. The first two are the
@@ -49,24 +50,30 @@ circles to be. Multiple formats supported (e.g. hexadecimal).}
 
 \item{nodeClickColour}{character string specifying the colour you want the
 node circles to be when they are clicked. Also changes the colour of the
-text. Multiple formats supported (e.g. hexadecimal).}
+text. Multiple formats supported (e.g. hexadecimal). Set to \code{NULL}
+to not change color when clicked.}
 
 \item{textColour}{character string specifying the colour you want the text to
 be before they are clicked. Multiple formats supported (e.g. hexadecimal).}
 
 \item{opacity}{numeric value of the proportion opaque you would like the
-  graph elements to be.}
+graph elements to be.}
+
+\item{directed}{TRUE draws a directed graph with arrows, FALSE draws
+  an undirected graph (the default).}
 }
 \description{
 \code{simpleNetwork} creates simple D3 JavaScript force directed network
 graphs.
 }
 \note{
-The \code{linkColour}, \code{nodeColour}, \code{textColour}, \code{nodeClickColour}, and
+The \code{linkColour}, \code{nodeColour}, \code{textColour}, and
  \code{opacity} parameters may be a single character string specifying values
  for all nodes and links, or they may be vectors of the same length as the
  number of nodes or links. The total number of unique nodes and their
- order is given by \code{unique(Reduce(c,t(Data)))}.
+ order is given by \code{unique(Reduce(c,t(Data)))} (see below for an example).
+ Alternatively, consider \code{forceNetwork} for additional output
+ options.
 }
 \examples{
 # Fake data
@@ -76,5 +83,10 @@ NetworkData <- data.frame(Source, Target)
 
 # Create graph
 simpleNetwork(NetworkData)
+
+# Alter the colors of each node.
+nodes <- unique(Reduce(c, t(NetworkData))) # Graph nodes in order
+# Note use of substring to remove alpha level from colors.
+simpleNetwork(NetworkData, nodeColour=substr(rainbow(length(nodes)),1,7))
 }
 

--- a/man/simpleNetwork.Rd
+++ b/man/simpleNetwork.Rd
@@ -62,7 +62,7 @@ be before they are clicked. Multiple formats supported (e.g. hexadecimal).}
 graphs.
 }
 \note{
-The \code{linkColour}, \code{nodeColour}, \code{textColour}, and
+The \code{linkColour}, \code{nodeColour}, \code{textColour}, \code{nodeClickColour}, and
  \code{opacity} parameters may be a single character string specifying values
  for all nodes and links, or they may be vectors of the same length as the
  number of nodes or links. The total number of unique nodes and their

--- a/man/simpleNetwork.Rd
+++ b/man/simpleNetwork.Rd
@@ -61,6 +61,12 @@ be before they are clicked. Multiple formats supported (e.g. hexadecimal).}
 \code{simpleNetwork} creates simple D3 JavaScript force directed network
 graphs.
 }
+\note{
+The \code{linkColour}, \code{nodeColour}, \code{textColour}, and
+ \code{opacity} parameters may be a single character string specifying values
+ for all nodes and links, or they may be vectors of the same length as the
+ number of rows in \code{Data} specifying a value per row.
+}
 \examples{
 # Fake data
 Source <- c("A", "A", "A", "A", "B", "B", "C", "C", "D")


### PR DESCRIPTION
A few new and revised options for simpleNetwork that are backwards-compatible with the current CRAN version.

* vertex and link color and opacity
* directed networks
* new examples and doc entries