### PR TITLE
Allow user to define node color

### DIFF
--- a/R/forceNetwork.R
+++ b/R/forceNetwork.R
@@ -18,6 +18,8 @@
 #' data frame.
 #' @param Group character string specifying the group of each node in the
 #' \code{Nodes} data frame.
+#' @param Color character string specifying the color of each node in the
+#' \code{Nodes} data frame.
 #' @param height numeric height for the network graph's frame area in pixels.
 #' @param width numeric width for the network graph's frame area in pixels.
 #' @param colourScale character string specifying the categorical colour
@@ -72,64 +74,74 @@
 #'
 #' @export
 forceNetwork <- function(Links, Nodes, Source, Target, Value, NodeID,
-    Group, height = NULL, width = NULL, colourScale = "d3.scale.category20()",
-    fontsize = 7, linkDistance = 50,
-    linkWidth = "function(d) { return Math.sqrt(d.value); }", charge = -120,
-    linkColour = "#666",opacity = 0.6)
+                         Group, Color = NULL, height = NULL, width = NULL, colourScale = "d3.scale.category20()",
+                         fontsize = 7, linkDistance = 50,
+                         linkWidth = "function(d) { return Math.sqrt(d.value); }", charge = -120,
+                         linkColour = "#666",opacity = 0.6)
 {
-    # Subset data frames for network graph
-    if (!is.data.frame(Links)){
-        stop("Links must be a data frame class object.")
-    }
-    if (!is.data.frame(Nodes)){
-        stop("Nodes must be a data frame class object.")
-    }
-    if (missing(Value)){
-        LinksDF <- data.frame(Links[, Source], Links[, Target])
-        names(LinksDF) <- c("source", "target")
-    }
-    else if (!missing(Value)){
-        LinksDF <- data.frame(Links[, Source], Links[, Target], Links[, Value])
-        names(LinksDF) <- c("source", "target", "value")
-    }
+  # Subset data frames for network graph
+  if (!is.data.frame(Links)){
+    stop("Links must be a data frame class object.")
+  }
+  if (!is.data.frame(Nodes)){
+    stop("Nodes must be a data frame class object.")
+  }
+  if (missing(Value)){
+    LinksDF <- data.frame(Links[, Source], Links[, Target])
+    names(LinksDF) <- c("source", "target")
+  }
+  else if (!missing(Value)){
+    LinksDF <- data.frame(Links[, Source], Links[, Target], Links[, Value])
+    names(LinksDF) <- c("source", "target", "value")
+  }
+  
+  if (missing(Color)){
     NodesDF <- data.frame(Nodes[, NodeID], Nodes[, Group])
     names(NodesDF) <- c("name", "group")
-
-    # create options
-    options = list(
-        NodeID = NodeID,
-        Group = Group,
-        colourScale = colourScale,
-        fontsize = fontsize,
-        clickTextSize = fontsize * 2.5,
-        linkDistance = linkDistance,
-        linkWidth = linkWidth,
-        charge = charge,
-        linkColour = linkColour,
-        opacity = opacity
-    )
-
-    # create widget
-    htmlwidgets::createWidget(
-        name = "forceNetwork",
-        x = list(links = LinksDF, nodes = NodesDF, options = options),
-        width = width,
-        height = height,
-        htmlwidgets::sizingPolicy(padding = 0, browser.fill = TRUE),
-        package = "networkD3"
-    )
+  }
+  else if (!missing(Color)){
+    NodesDF <- data.frame(Nodes[, NodeID], Nodes[, Group], Nodes[, Color])
+    names(NodesDF) <- c("name", "group", "color")
+  }
+  
+  
+  
+  
+  # create options
+  options = list(
+    NodeID = NodeID,
+    Group = Group,
+    colourScale = colourScale,
+    fontsize = fontsize,
+    clickTextSize = fontsize * 2.5,
+    linkDistance = linkDistance,
+    linkWidth = linkWidth,
+    charge = charge,
+    linkColour = linkColour,
+    opacity = opacity
+  )
+  
+  # create widget
+  htmlwidgets::createWidget(
+    name = "forceNetwork",
+    x = list(links = LinksDF, nodes = NodesDF, options = options),
+    width = width,
+    height = height,
+    htmlwidgets::sizingPolicy(padding = 0, browser.fill = TRUE),
+    package = "networkD3"
+  )
 }
 
 #' @rdname networkD3-shiny
 #' @export
 forceNetworkOutput <- function(outputId, width = "100%", height = "500px") {
-    shinyWidgetOutput(outputId, "forceNetwork", width, height,
-    package = "networkD3")
+  shinyWidgetOutput(outputId, "forceNetwork", width, height,
+                    package = "networkD3")
 }
 
 #' @rdname networkD3-shiny
 #' @export
 renderForceNetwork <- function(expr, env = parent.frame(), quoted = FALSE) {
-    if (!quoted) { expr <- substitute(expr) } # force quoted
-    shinyRenderWidget(expr, forceNetworkOutput, env, quoted = TRUE)
+  if (!quoted) { expr <- substitute(expr) } # force quoted
+  shinyRenderWidget(expr, forceNetworkOutput, env, quoted = TRUE)
 }

--- a/inst/htmlwidgets/forceNetwork.js
+++ b/inst/htmlwidgets/forceNetwork.js
@@ -97,7 +97,7 @@ HTMLWidgets.widget({
       .data(force.nodes())
       .enter().append("g")
       .attr("class", "node")
-      .style("fill", function(d) { return color(d.group); })
+      .style("fill", function(d) { if (d.color) { return d.color } else { return color(d.group) }})
       .style("opacity", options.opacity)
       .on("mouseover", mouseover)
       .on("mouseout", mouseout)

--- a/man/forceNetwork.Rd
+++ b/man/forceNetwork.Rd
@@ -9,7 +9,7 @@ specifically for force directed networks
 \url{https://github.com/mbostock/d3/wiki/Force-Layout}.
 }
 \usage{
-forceNetwork(Links, Nodes, Source, Target, Value, NodeID, Group,
+forceNetwork(Links, Nodes, Source, Target, Value, NodeID, Group, Color = NULL,
   height = NULL, width = NULL, colourScale = "d3.scale.category20()",
   fontsize = 7, linkDistance = 50,
   linkWidth = "function(d) { return Math.sqrt(d.value); }", charge = -120,
@@ -39,6 +39,9 @@ frame for how wide the links are.}
 data frame.}
 
 \item{Group}{character string specifying the group of each node in the
+\code{Nodes} data frame.}
+
+\item{Color}{character string specifying the color of each node in the
 \code{Nodes} data frame.}
 
 \item{height}{numeric height for the network graph's frame area in pixels.}
@@ -99,4 +102,3 @@ forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Group = "group", opacity = 0.4)
 }
 }
-


### PR DESCRIPTION
This allows the user to define colors for specific nodes in the data
frame. This way if the data is subsetted and the number of groups change
the coloring stays consistent.

If no color value is specified it simply defaults back to the scalar.

update: For some reason it appears my text editor changed some white space in forceNetwork.R, hence why that looks so messy. It's compiled and working on my computer. The actual code isn't nearly that confusing.