### PR TITLE
Add ability to set fontFamily in R

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,15 @@
 # All changes to networkD3 are documented here.
 
+
+
 ## Version 0.1.8
 
 - Added `bounded` argument to `forceNetwork` to allow the user to created a
 bounding box for the plot. See http://bl.ocks.org/mbostock/1129492.
 Thank you to Charles Sese.
+
+- Add fontFamily option for forceNetwork, simpleNetwork, sankeyNetwork and treeNetwork
+Thanks to Peter Ellis.
 
 ## Version 0.1.7
 

--- a/R/forceNetwork.R
+++ b/R/forceNetwork.R
@@ -27,6 +27,7 @@
 #' scale for the nodes. See
 #' \url{https://github.com/mbostock/d3/wiki/Ordinal-Scales}.
 #' @param fontSize numeric font size in pixels for the node text labels.
+#' @param fontFamily font family for the node text labels.
 #' @param linkDistance numeric or character string. Either numberic fixed
 #' distance between the links in pixels (actually arbitrary relative to the
 #' diagram's size). Or a JavaScript function, possibly to weight by
@@ -118,6 +119,7 @@ forceNetwork <- function(Links,
                          width = NULL,
                          colourScale = JS("d3.scale.category20()"),
                          fontSize = 7,
+                         fontFamily = "serif",
                          linkDistance = 50,
                          linkWidth = JS("function(d) { return Math.sqrt(d.value); }"),
                          radiusCalculation = JS(" Math.sqrt(d.nodesize)+6"),
@@ -164,6 +166,7 @@ forceNetwork <- function(Links,
                 Group = Group,
                 colourScale = colourScale,
                 fontSize = fontSize,
+                fontFamily = fontFamily,
                 clickTextSize = fontSize * 2.5,
                 linkDistance = linkDistance,
                 linkWidth = linkWidth,

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -22,6 +22,7 @@
 #' scale for the nodes. See
 #' \url{https://github.com/mbostock/d3/wiki/Ordinal-Scales}.
 #' @param fontSize numeric font size in pixels for the node text labels.
+#' @param fontFamily font family for the node text labels.
 #' @param nodeWidth numeric width of each node.
 #' @param nodePadding numeric essentially influences the width height.
 #'
@@ -63,6 +64,7 @@ sankeyNetwork <- function(Links,
                           width = NULL,
                           colourScale = JS("d3.scale.category20()"),
                           fontSize = 7,
+                          fontFamily = "serif",
                           nodeWidth = 15,
                           nodePadding = 10)
 {
@@ -92,6 +94,7 @@ sankeyNetwork <- function(Links,
         NodeID = NodeID,
         colourScale = colourScale,
         fontSize = fontSize,
+        fontFamily = fontFamily,
         nodeWidth = nodeWidth,
         nodePadding = nodePadding
     )

--- a/R/simpleNetwork.R
+++ b/R/simpleNetwork.R
@@ -21,6 +21,7 @@
 #' @param charge numeric value indicating either the strength of the node
 #'   repulsion (negative value) or attraction (positive value).
 #' @param fontSize numeric font size in pixels for the node text labels.
+#' @param fontFamily font family for the node text labels.
 #' @param linkColour character string specifying the colour you want the link
 #'   lines to be. Multiple formats supported (e.g. hexadecimal).
 #' @param nodeColour character string specifying the colour you want the node
@@ -43,6 +44,7 @@
 #'
 #' # Create graph
 #' simpleNetwork(NetworkData)
+#' simpleNetwork(NetworkData, fontFamily = "sans serif")
 #'
 #' @source D3.js was created by Michael Bostock. See \url{http://d3js.org/} and,
 #'   more specifically for directed networks
@@ -57,6 +59,7 @@ simpleNetwork <- function(Data,
                           linkDistance = 50,
                           charge = -200,
                           fontSize = 7,
+                          fontFamily = "serif",
                           linkColour = "#666",
                           nodeColour = "#3182bd",
                           nodeClickColour = "#E34A33",
@@ -80,6 +83,7 @@ simpleNetwork <- function(Data,
         linkDistance = linkDistance,
         charge = charge,
         fontSize = fontSize,
+        fontFamily = fontFamily,
         linkColour = linkColour,
         nodeColour = nodeColour,
         nodeClickColour = nodeClickColour,

--- a/R/treeNetwork.R
+++ b/R/treeNetwork.R
@@ -6,6 +6,7 @@
 #' @param width numeric width for the network graph's frame area in pixels (if
 #'   \code{NULL} then width is automatically determined based on context)
 #' @param fontSize numeric font size in pixels for the node text labels.
+#' @param fontFamily font family for the node text labels.
 #' @param linkColour character string specifying the colour you want the link
 #' lines to be. Multiple formats supported (e.g. hexadecimal).
 #' @param nodeColour character string specifying the colour you want the node
@@ -39,6 +40,7 @@
 #' #### Create a tree dendrogram from an R hclust object
 #' hc <- hclust(dist(USArrests), "ave")
 #' treeNetwork(as.treeNetwork(hc))
+#' treeNetwork(as.treeNetwork(hc), fontFamily = "Arial")
 #'
 #' #### Create tree from a hierarchical R list
 #' For an alternative structure see: http://stackoverflow.com/a/30747323/1705044
@@ -89,6 +91,7 @@ treeNetwork <- function(
                           height = NULL,
                           width = NULL,
                           fontSize = 10,
+                          fontFamily = "serif",
                           linkColour = "#ccc",
                           nodeColour = "#fff",
                           nodeStroke = "steelblue",
@@ -106,6 +109,7 @@ treeNetwork <- function(
         height = height,
         width = width,
         fontSize = fontSize,
+        fontFamily = fontFamily,
         linkColour = linkColour,
         nodeColour = nodeColour,
         nodeStroke = nodeStroke,

--- a/inst/examples/examples.R
+++ b/inst/examples/examples.R
@@ -7,6 +7,12 @@ target <- c("B", "C", "D", "J", "E", "F", "G", "H", "I")
 networkData <- data.frame(src, target)
 simpleNetwork(networkData)
 
+# with R's sans serif font (might not be recognised in browser; works in RStudio pane)
+simpleNetwork(networkData, fontFamily = "sans serif")
+
+# with Arial (works in browser as well):
+simpleNetwork(networkData, fontFamily = "Arial")
+
 # forceNetwork 
 data(MisLinks)
 data(MisNodes)
@@ -15,6 +21,13 @@ data(MisNodes)
 forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Target = "target", Value = "value", NodeID = "name",
              Group = "group", opacity = 1, zoom = F, bounded = T)
+
+# With Arial font
+forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
+             Target = "target", Value = "value", NodeID = "name",
+             Group = "group", opacity = 1, zoom = F, bounded = T,
+             fontFamily = "Arial")
+
 
 # Create graph with legend and varying radius
 forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
@@ -27,6 +40,10 @@ forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Target = "target", Value = "value", NodeID = "name",
              Nodesize = 'size', radiusCalculation = " Math.sqrt(d.nodesize)+6",
              Group = "group", opacity = 1, legend = T, bounded = T) 
+
+
+
+
 
 # sankeyNetwork
 library(RCurl)
@@ -41,7 +58,16 @@ sankeyNetwork(Links = EngLinks, Nodes = EngNodes, Source = "source",
               Target = "target", Value = "value", NodeID = "name",
               fontSize = 12, nodeWidth = 30)
 
+# And with Arial font
+sankeyNetwork(Links = EngLinks, Nodes = EngNodes, Source = "source",
+              Target = "target", Value = "value", NodeID = "name",
+              fontSize = 12, nodeWidth = 30, fontFamily = "Arial")
+
+
 # treeNetwork
 Flare <- RCurl::getURL("https://gist.githubusercontent.com/mbostock/4063550/raw/a05a94858375bd0ae023f6950a2b13fac5127637/flare.json")
 Flare <- rjson::fromJSON(Flare)
 treeNetwork(List = Flare, fontSize = 10, opacity = 0.9, margin=0)
+
+# and with Arial font
+treeNetwork(List = Flare, fontSize = 10, opacity = 0.9, margin=0, fontFamily = "Arial")

--- a/inst/htmlwidgets/forceNetwork.js
+++ b/inst/htmlwidgets/forceNetwork.js
@@ -136,7 +136,7 @@ HTMLWidgets.widget({
       .attr("dx", 12)
       .attr("dy", ".35em")
       .text(function(d) { return d.name })
-      .style("font", options.fontSize + "px serif")
+      .style("font", options.fontSize + "px " + options.fontFamily)
       .style("opacity", 0)
       .style("pointer-events", "none");
 
@@ -177,7 +177,7 @@ HTMLWidgets.widget({
         .duration(750)
         .attr("x", 13)
         .style("stroke-width", ".5px")
-        .style("font", options.clickTextSize + "px serif")
+        .style("font", options.clickTextSize + "px " + options.fontFamily)
         .style("opacity", 1);
     }
 

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -118,7 +118,7 @@ HTMLWidgets.widget({
             .attr("text-anchor", "end")
             .attr("transform", null)
             .text(function(d) { return d.name; })
-            .style("font", options.fontSize + "px serif")
+            .style("font", options.fontSize + "px " + x.options.fontFamily)
             .filter(function(d) { return d.x < width / 2; })
             .attr("x", 6 + sankey.nodeWidth())
             .attr("text-anchor", "start");

--- a/inst/htmlwidgets/simpleNetwork.js
+++ b/inst/htmlwidgets/simpleNetwork.js
@@ -118,7 +118,7 @@ HTMLWidgets.widget({
     node.append("text")
       .attr("x", 12)
       .attr("dy", ".35em")
-      .style("font", x.options.fontSize + "px serif")
+      .style("font", x.options.fontSize + "px " + x.options.fontFamily)
       .style("fill", x.options.textColour)
       .style("opacity", x.options.opacity)
       .style("pointer-events", "none")
@@ -158,7 +158,7 @@ HTMLWidgets.widget({
         .style("stroke-width", ".5px")
         .style("opacity", 1)
         .style("fill", x.options.nodeClickColour)
-        .style("font", x.options.clickTextSize + "px serif");
+        .style("font", x.options.clickTextSize + "px " + x.options.fontFamily);
       d3.select(this).select("circle").transition()
         .duration(750)
         .style("fill", x.options.nodeClickColour)
@@ -178,7 +178,7 @@ HTMLWidgets.widget({
         .style("fill", x.options.nodeClickColour)
         .style("stroke", "none")
         .style("opacity", x.options.opacity)
-        .style("font", x.options.fontSize + "px serif");
+        .style("font", x.options.fontSize + "px " + x.options.fontFamily);
     }
   },
 });

--- a/inst/htmlwidgets/treeNetwork.js
+++ b/inst/htmlwidgets/treeNetwork.js
@@ -84,7 +84,7 @@ HTMLWidgets.widget({
         .attr("dy", ".31em")
         .attr("text-anchor", function(d) { return d.x < 180 ? "start" : "end"; })
         .attr("transform", function(d) { return d.x < 180 ? "translate(8)" : "rotate(180)translate(-8)"; })
-        .style("font", x.options.fontSize + "px serif")
+        .style("font", x.options.fontSize + "px " + x.options.fontFamily)
         .style("opacity", x.options.opacity)
         .style("fill", x.options.textColour)
         .text(function(d) { return d.name; });
@@ -100,7 +100,7 @@ HTMLWidgets.widget({
         .attr("text-anchor", function(d) { return d.x < 180 ? "start" : "end"; })
         .attr("transform", function(d) { return d.x < 180 ? "translate(8)" : "rotate(180)translate(-8)"; })
         .style("stroke-width", ".5px")
-        .style("font", "25px serif")
+        .style("font", "25px " + x.options.fontFamily)
         .style("opacity", 1);
     }
 
@@ -114,7 +114,7 @@ HTMLWidgets.widget({
         .attr("dy", ".31em")
         .attr("text-anchor", function(d) { return d.x < 180 ? "start" : "end"; })
         .attr("transform", function(d) { return d.x < 180 ? "translate(8)" : "rotate(180)translate(-8)"; })
-        .style("font", x.options.fontSize + "px serif")
+        .style("font", x.options.fontSize + "px " + x.options.fontFamily)
         .style("opacity", x.options.opacity);
     }
 

--- a/man/forceNetwork.Rd
+++ b/man/forceNetwork.Rd
@@ -11,7 +11,7 @@ specifically for force directed networks
 \usage{
 forceNetwork(Links, Nodes, Source, Target, Value, NodeID, Nodesize, Group,
   height = NULL, width = NULL, colourScale = JS("d3.scale.category20()"),
-  fontSize = 7, linkDistance = 50,
+  fontSize = 7, fontFamily = "serif", linkDistance = 50,
   linkWidth = JS("function(d) { return Math.sqrt(d.value); }"),
   radiusCalculation = JS(" Math.sqrt(d.nodesize)+6"), charge = -120,
   linkColour = "#666", opacity = 0.6, zoom = FALSE, legend = FALSE,
@@ -56,6 +56,8 @@ scale for the nodes. See
 \url{https://github.com/mbostock/d3/wiki/Ordinal-Scales}.}
 
 \item{fontSize}{numeric font size in pixels for the node text labels.}
+
+\item{fontFamily}{font family for the node text labels.}
 
 \item{linkDistance}{numeric or character string. Either numberic fixed
 distance between the links in pixels (actually arbitrary relative to the

--- a/man/sankeyNetwork.Rd
+++ b/man/sankeyNetwork.Rd
@@ -10,7 +10,7 @@ specifically for Sankey diagrams \url{http://bost.ocks.org/mike/sankey/}.
 \usage{
 sankeyNetwork(Links, Nodes, Source, Target, Value, NodeID, height = NULL,
   width = NULL, colourScale = JS("d3.scale.category20()"), fontSize = 7,
-  nodeWidth = 15, nodePadding = 10)
+  fontFamily = "serif", nodeWidth = 15, nodePadding = 10)
 }
 \arguments{
 \item{Links}{a data frame object with the links between the nodes. It should
@@ -44,6 +44,8 @@ scale for the nodes. See
 \url{https://github.com/mbostock/d3/wiki/Ordinal-Scales}.}
 
 \item{fontSize}{numeric font size in pixels for the node text labels.}
+
+\item{fontFamily}{font family for the node text labels.}
 
 \item{nodeWidth}{numeric width of each node.}
 

--- a/man/simpleNetwork.Rd
+++ b/man/simpleNetwork.Rd
@@ -11,7 +11,7 @@ D3.js was created by Michael Bostock. See \url{http://d3js.org/} and,
 \usage{
 simpleNetwork(Data, Source = NULL, Target = NULL, height = NULL,
   width = NULL, linkDistance = 50, charge = -200, fontSize = 7,
-  linkColour = "#666", nodeColour = "#3182bd",
+  fontFamily = "serif", linkColour = "#666", nodeColour = "#3182bd",
   nodeClickColour = "#E34A33", textColour = "#3182bd", opacity = 0.6,
   zoom = F)
 }
@@ -41,6 +41,8 @@ arbitrary relative to the diagram's size).}
 repulsion (negative value) or attraction (positive value).}
 
 \item{fontSize}{numeric font size in pixels for the node text labels.}
+
+\item{fontFamily}{font family for the node text labels.}
 
 \item{linkColour}{character string specifying the colour you want the link
 lines to be. Multiple formats supported (e.g. hexadecimal).}
@@ -73,5 +75,6 @@ NetworkData <- data.frame(Source, Target)
 
 # Create graph
 simpleNetwork(NetworkData)
+simpleNetwork(NetworkData, fontFamily = "sans serif")
 }
 

--- a/man/treeNetwork.Rd
+++ b/man/treeNetwork.Rd
@@ -11,8 +11,9 @@ Mike Bostock: \url{http://bl.ocks.org/mbostock/4063550}.
 }
 \usage{
 treeNetwork(List, height = NULL, width = NULL, fontSize = 10,
-  linkColour = "#ccc", nodeColour = "#fff", nodeStroke = "steelblue",
-  textColour = "#111", opacity = 0.9, margin = 0)
+  fontFamily = "serif", linkColour = "#ccc", nodeColour = "#fff",
+  nodeStroke = "steelblue", textColour = "#111", opacity = 0.9,
+  margin = 0)
 }
 \arguments{
 \item{List}{a hierarchical list object with a root node and children.}
@@ -24,6 +25,8 @@ treeNetwork(List, height = NULL, width = NULL, fontSize = 10,
 \code{NULL} then width is automatically determined based on context)}
 
 \item{fontSize}{numeric font size in pixels for the node text labels.}
+
+\item{fontFamily}{font family for the node text labels.}
 
 \item{linkColour}{character string specifying the colour you want the link
 lines to be. Multiple formats supported (e.g. hexadecimal).}
@@ -65,6 +68,7 @@ treeNetwork(List = Flare, fontSize = 10, opacity = 0.9)
 #### Create a tree dendrogram from an R hclust object
 hc <- hclust(dist(USArrests), "ave")
 treeNetwork(as.treeNetwork(hc))
+treeNetwork(as.treeNetwork(hc), fontFamily = "Arial")
 
 #### Create tree from a hierarchical R list
 For an alternative structure see: http://stackoverflow.com/a/30747323/1705044


### PR DESCRIPTION
This PR allows the user to specify a fontFamily argument to forceNetwork(), simpleNetwork(), sankeyNetwork and treeNetwork, hence addressing #15 and further, allowing the font family to be controlled in R rather than via CSS.

All default behaviour should be unchanged as fontFamily defaults to serif, but this PR makes it easy for users to use sans serif for network charts in R (if rendering in RStudio), or any browser-recognised font for sankeyNetwork and treeNetwork, ie without modifying the resulting object with JavaScript.