### PR TITLE
Improve font examples to use default fonts; and fix small bounding box bug

### DIFF
--- a/R/simpleNetwork.R
+++ b/R/simpleNetwork.R
@@ -44,7 +44,7 @@
 #'
 #' # Create graph
 #' simpleNetwork(NetworkData)
-#' simpleNetwork(NetworkData, fontFamily = "sans serif")
+#' simpleNetwork(NetworkData, fontFamily = "sans-serif")
 #'
 #' @source D3.js was created by Michael Bostock. See \url{http://d3js.org/} and,
 #'   more specifically for directed networks

--- a/R/treeNetwork.R
+++ b/R/treeNetwork.R
@@ -40,7 +40,7 @@
 #' #### Create a tree dendrogram from an R hclust object
 #' hc <- hclust(dist(USArrests), "ave")
 #' treeNetwork(as.treeNetwork(hc))
-#' treeNetwork(as.treeNetwork(hc), fontFamily = "Arial")
+#' treeNetwork(as.treeNetwork(hc), fontFamily = "cursive")
 #'
 #' #### Create tree from a hierarchical R list
 #' For an alternative structure see: http://stackoverflow.com/a/30747323/1705044

--- a/inst/examples/examples.R
+++ b/inst/examples/examples.R
@@ -7,11 +7,11 @@ target <- c("B", "C", "D", "J", "E", "F", "G", "H", "I")
 networkData <- data.frame(src, target)
 simpleNetwork(networkData)
 
-# with R's sans serif font (might not be recognised in browser; works in RStudio pane)
-simpleNetwork(networkData, fontFamily = "sans serif")
+# with sans-serif 
+simpleNetwork(networkData, fontFamily = "sans-serif")
 
-# with Arial (works in browser as well):
-simpleNetwork(networkData, fontFamily = "Arial")
+# with another font 
+simpleNetwork(networkData, fontFamily = "fantasy")
 
 # forceNetwork 
 data(MisLinks)
@@ -22,11 +22,11 @@ forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Target = "target", Value = "value", NodeID = "name",
              Group = "group", opacity = 1, zoom = F, bounded = T)
 
-# With Arial font
+# With a different font
 forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Target = "target", Value = "value", NodeID = "name",
              Group = "group", opacity = 1, zoom = F, bounded = T,
-             fontFamily = "Arial")
+             fontFamily = "cursive")
 
 
 # Create graph with legend and varying radius
@@ -58,10 +58,10 @@ sankeyNetwork(Links = EngLinks, Nodes = EngNodes, Source = "source",
               Target = "target", Value = "value", NodeID = "name",
               fontSize = 12, nodeWidth = 30)
 
-# And with Arial font
+# And with a different font
 sankeyNetwork(Links = EngLinks, Nodes = EngNodes, Source = "source",
               Target = "target", Value = "value", NodeID = "name",
-              fontSize = 12, nodeWidth = 30, fontFamily = "Arial")
+              fontSize = 12, nodeWidth = 30, fontFamily = "monospace")
 
 
 # treeNetwork
@@ -69,5 +69,5 @@ Flare <- RCurl::getURL("https://gist.githubusercontent.com/mbostock/4063550/raw/
 Flare <- rjson::fromJSON(Flare)
 treeNetwork(List = Flare, fontSize = 10, opacity = 0.9, margin=0)
 
-# and with Arial font
-treeNetwork(List = Flare, fontSize = 10, opacity = 0.9, margin=0, fontFamily = "Arial")
+# and with a different font
+treeNetwork(List = Flare, fontSize = 10, opacity = 0.9, margin=0, fontFamily = "sans-serif")

--- a/inst/examples/examples.R
+++ b/inst/examples/examples.R
@@ -22,11 +22,12 @@ forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Target = "target", Value = "value", NodeID = "name",
              Group = "group", opacity = 1, zoom = F, bounded = T)
 
-# With a different font
+# With a different font, and dimensions chosen to illustrate bounded box
 forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Target = "target", Value = "value", NodeID = "name",
              Group = "group", opacity = 1, zoom = F, bounded = T,
-             fontFamily = "cursive")
+             fontFamily = "cursive",
+             width = 1500, height = 300)
 
 
 # Create graph with legend and varying radius

--- a/inst/htmlwidgets/forceNetwork.js
+++ b/inst/htmlwidgets/forceNetwork.js
@@ -148,7 +148,7 @@ HTMLWidgets.widget({
         }else{
             return d.x}
     }
-    function nodeBoxY(d,width) {
+    function nodeBoxY(d, height) {
         if(options.bounded){
             var dy = Math.max(nodeSize(d), Math.min(height - nodeSize(d), d.y));
             return dy;

--- a/man/simpleNetwork.Rd
+++ b/man/simpleNetwork.Rd
@@ -75,6 +75,6 @@ NetworkData <- data.frame(Source, Target)
 
 # Create graph
 simpleNetwork(NetworkData)
-simpleNetwork(NetworkData, fontFamily = "sans serif")
+simpleNetwork(NetworkData, fontFamily = "sans-serif")
 }
 

--- a/man/treeNetwork.Rd
+++ b/man/treeNetwork.Rd
@@ -68,7 +68,7 @@ treeNetwork(List = Flare, fontSize = 10, opacity = 0.9)
 #### Create a tree dendrogram from an R hclust object
 hc <- hclust(dist(USArrests), "ave")
 treeNetwork(as.treeNetwork(hc))
-treeNetwork(as.treeNetwork(hc), fontFamily = "Arial")
+treeNetwork(as.treeNetwork(hc), fontFamily = "cursive")
 
 #### Create tree from a hierarchical R list
 For an alternative structure see: http://stackoverflow.com/a/30747323/1705044


### PR DESCRIPTION
This PR improves the various example uses of fontFamily so they all use one of the five fall back fonts available to all browsers.  It also fixes a small, possibly non-mattering, bug to the bounding box in forceNetwork.js where one of the helper functions was deriving a value from the environment one step up rather than its arguments.