### PR TITLE
Add ability to specify a clickAction to forceNetwork when a node is clicked

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,11 @@
 
 ## Version 0.1.8
 
-- Added `bounded` argument to `forceNetwork` to allow the user to created a
+- Added `clickAction` argument to `forceNetwork` to allow the user to
+pass a JavaScript expression through to be activated on click of a node.
+Thanks to Peter Ellis.
+
+- Added `bounded` argument to `forceNetwork` to allow the user to create a
 bounding box for the plot. See http://bl.ocks.org/mbostock/1129492.
 Thanks to Charles Sese.
 

--- a/R/forceNetwork.R
+++ b/R/forceNetwork.R
@@ -54,7 +54,8 @@
 #' \url{http://bl.ocks.org/mbostock/1129492}.
 #' @param opacityNoHover numeric value of the opacity proportion for node labels 
 #' text when the mouse is not hovering over them
-#'
+#' @param clickAction A JavaScript expression to evaluate when a node is clicked
+#' 
 #' @examples
 #' #### Tabular data example.
 #' # Load data
@@ -105,6 +106,21 @@
 #'              Target = "target", Value = "value", NodeID = "name",
 #'              Group = "group", opacity = 0.4, bounded = TRUE,
 #'              opacityNoHover = TRUE)
+#'              
+#'              
+#' # Create graph with alert pop-up when a node is clicked.  You're 
+#' # unlikely to want to do exactly this, but you might use
+#' # Shiny.onInputChange() to allocate d.XXX to an element of input
+#' # for use in a Shiny app.
+#' MyClickScript <- 'alert("You clicked " + d.name + " which is in row " + 
+#'        (d.index + 1) +  " of your original R data frame");'
+#' forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
+#'              Target = "target", Value = "value", NodeID = "name",
+#'              Group = "group", opacity = 1, zoom = F, bounded = T,
+#'              clickAction = MyClickScript)
+#'              
+#'              
+#'              
 #' }
 #'
 
@@ -137,7 +153,8 @@ forceNetwork <- function(Links,
                          zoom = FALSE,
                          legend = FALSE,
                          bounded = FALSE,
-                         opacityNoHover = 0)
+                         opacityNoHover = 0,
+                         clickAction = NULL)
 {
         # Hack for UI consistency. Think of improving.
         colourScale <- as.character(colourScale)
@@ -187,7 +204,8 @@ forceNetwork <- function(Links,
                 nodesize = nodesize,
                 radiusCalculation = radiusCalculation,
                 bounded = bounded,
-                opacityNoHover = opacityNoHover
+                opacityNoHover = opacityNoHover,
+                clickAction = clickAction
         )
 
         # create widget

--- a/inst/examples/examples.R
+++ b/inst/examples/examples.R
@@ -22,6 +22,43 @@ forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Target = "target", Value = "value", NodeID = "name",
              Group = "group", opacity = 1, zoom = F, bounded = T)
 
+# with a simple click action - make the circles bigger when clicked
+MyClickScript <- 
+  '      d3.select(this).select("circle").transition()
+        .duration(750)
+        .attr("r", 30)'
+
+forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
+             Target = "target", Value = "value", NodeID = "name",
+             Group = "group", opacity = 1, zoom = F, bounded = T,
+             clickAction = MyClickScript)
+
+# showing how you can re-use the name of the clicked-on node (which is 'd')
+# You are unlikely to want to do this pop-up alert, but you might want 
+# instead to use Shiny.onInputChange() to allocate d.XXX to an element
+# input$XXX for user in a Shiny app.
+MyClickScript <- 'alert("You clicked " + d.name + " which is in row " + (d.index + 1) +
+                        " of your original R data frame");'
+forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
+             Target = "target", Value = "value", NodeID = "name",
+             Group = "group", opacity = 1, zoom = F, bounded = T,
+             clickAction = MyClickScript)
+
+
+
+forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
+             Target = "target", Value = "value", NodeID = "name",
+             Group = "group", opacity = 1, zoom = F, bounded = T,
+             clickAction = "alert('Ouch!')")
+
+
+
+
+
+#
+
+
+
 # With a different font, and dimensions chosen to illustrate bounded box
 forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Target = "target", Value = "value", NodeID = "name",
@@ -30,11 +67,11 @@ forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              width = 1500, height = 300)
 
 
-# With Arial font, and node text faintly visible when not hovered over
+# With a different font, and node text faintly visible when not hovered over
 forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Target = "target", Value = "value", NodeID = "name",
              Group = "group", opacity = 1, zoom = F, bounded = T,
-             fontFamily = "Arial", opacityNoHover = 0.3)
+             fontFamily = "cursive", opacityNoHover = 0.3)
 
 # Create graph with legend and varying radius
 forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",

--- a/inst/htmlwidgets/forceNetwork.js
+++ b/inst/htmlwidgets/forceNetwork.js
@@ -123,6 +123,7 @@ HTMLWidgets.widget({
       .style("opacity", options.opacity)
       .on("mouseover", mouseover)
       .on("mouseout", mouseout)
+      .on("click", click)
       .call(force.drag);
 
     node.append("circle")
@@ -190,6 +191,10 @@ HTMLWidgets.widget({
         .attr("x", 0)
         .style("font", options.fontSize + "px " + options.fontFamily) 
         .style("opacity", options.opacityNoHover);
+    }
+    
+    function click(d) {
+      return eval(options.clickAction)
     }
 
     // add legend option

--- a/man/forceNetwork.Rd
+++ b/man/forceNetwork.Rd
@@ -15,7 +15,7 @@ forceNetwork(Links, Nodes, Source, Target, Value, NodeID, Nodesize, Group,
   linkWidth = JS("function(d) { return Math.sqrt(d.value); }"),
   radiusCalculation = JS(" Math.sqrt(d.nodesize)+6"), charge = -120,
   linkColour = "#666", opacity = 0.6, zoom = FALSE, legend = FALSE,
-  bounded = FALSE, opacityNoHover = 0)
+  bounded = FALSE, opacityNoHover = 0, clickAction = NULL)
 }
 \arguments{
 \item{Links}{a data frame object with the links between the nodes. It should
@@ -94,6 +94,8 @@ zooming}
 
 \item{opacityNoHover}{numeric value of the opacity proportion for node labels
 text when the mouse is not hovering over them}
+
+\item{clickAction}{A JavaScript expression to evaluate when a node is clicked}
 }
 \description{
 Create a D3 JavaScript force directed network graph.
@@ -148,6 +150,21 @@ forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
              Target = "target", Value = "value", NodeID = "name",
              Group = "group", opacity = 0.4, bounded = TRUE,
              opacityNoHover = TRUE)
+
+
+# Create graph with alert pop-up when a node is clicked.  You're
+# unlikely to want to do exactly this, but you might use
+# Shiny.onInputChange() to allocate d.XXX to an element of input
+# for use in a Shiny app.
+MyClickScript <- 'alert("You clicked " + d.name + " which is in row " +
+       (d.index + 1) +  " of your original R data frame");'
+forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
+             Target = "target", Value = "value", NodeID = "name",
+             Group = "group", opacity = 1, zoom = F, bounded = T,
+             clickAction = MyClickScript)
+
+
+
 }
 }
 \seealso{


### PR DESCRIPTION
This PR lets the user control from within R a JavaScript action to take place when a node in a forceNetwork chart is clicked.  It could do something directly to the graphic, or it could be used in conjunction with Shiny.onInputChange() to pass data from the clicked node back to a Shiny app.  

If not used, behaviour stays the same as before the PR.

This would partially address #50 and #10 .

(These three PRs of mine recently have all been related to development of a complex Shiny app at my work; I think I'm done for now, in case you were wondering if small requested tweaks were going to come indefinitely....)