### PR TITLE
define redraw before referring to it in forceNetwork.js

### DIFF
--- a/inst/htmlwidgets/forceNetwork.js
+++ b/inst/htmlwidgets/forceNetwork.js
@@ -82,12 +82,12 @@ HTMLWidgets.widget({
 
     // add zooming if requested
     if (options.zoom) {
-      zoom.on("zoom", redraw)
       function redraw() {
         d3.select(el).select(".zoom-layer").attr("transform",
           "translate(" + d3.event.translate + ")"+
           " scale(" + d3.event.scale + ")");
       }
+      zoom.on("zoom", redraw)
 
       d3.select(el).select("svg")
         .attr("pointer-events", "all")


### PR DESCRIPTION
I happened on this today--since it seems the issue has been open for a few weeks, here's a PR following @ppernot's suggestion at https://github.com/christophergandrud/networkD3/issues/68

Many apologies if this is unhelpful. It seems to get forceNetwork() output working in Firefox on my system.