### PR TITLE
Fixing carriage returns for tooltips

### DIFF
--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -98,7 +98,7 @@ HTMLWidgets.widget({
 
         link.append("title")
             .text(function(d) { return d.source.name + d.target.name +
-                "\\n" + format(d.value); });
+                "\n" + format(d.value); });
 
         node.append("rect")
             .attr("height", function(d) { return d.dy; })
@@ -109,7 +109,7 @@ HTMLWidgets.widget({
             .style("opacity", 0.9)
             .style("cursor", "move")
             .append("title")
-            .text(function(d) { return d.name + "\\n" + format(d.value); });
+            .text(function(d) { return d.name + "\n" + format(d.value); });
 
         node.append("svg:text")
             .attr("x", -6)


### PR DESCRIPTION
Carriage returns were not working due to using \\n instead of \n. Note that this fix works in Chrome, but in RStudio it half-works (but is still better than the current): the carriage return will not work in nodes but does work in links.
