### PR TITLE
Added Link colourising to sankeyNetwork

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: D3 JavaScript Network Graphs from R
 Description: Creates 'D3' 'JavaScript' network, tree, dendrogram, and Sankey
     graphs from 'R'.
-Version: 0.2.1
+Version: 0.2.2
 Date: 2015-08-24
 Authors@R: c(
     person("Christopher", "Gandrud", email = "christopher.gandrud@gmail.com",

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 # All changes to networkD3 are documented here.
 
+## Version 0.2.2
+- Added NodeGroup and LinkGroup parameters to sankeyNetwork so links
+are colorised.
+
 ## Version 0.2.1
 
 - Fixed an issue with `forceNetwork` on Firefox. Thanks to @agoldst.

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -16,6 +16,10 @@
 #' frame for how far away the nodes are from one another.
 #' @param NodeID character string specifying the node IDs in the \code{Nodes}
 #' data frame.
+#' @param NodeGroup character string specifying the node groups in the 
+#' \code{Nodes}. Used to color the nodes in the network.
+#' @param LinkGroup character string specifying the groups in the 
+#' \code{Links}. Used to color the links in the network.
 #' @param units character string describing physical units (if any) for Value
 #' @param height numeric height for the network graph's frame area in pixels.
 #' @param width numeric width for the network graph's frame area in pixels.
@@ -61,6 +65,8 @@ sankeyNetwork <- function(Links,
                           Target,
                           Value,
                           NodeID,
+                          NodeGroup = NodeID,
+                          LinkGroup = NULL,
                           height = NULL,
                           width = NULL,
                           units = "",
@@ -90,10 +96,21 @@ sankeyNetwork <- function(Links,
     }
     NodesDF <- data.frame(Nodes[, NodeID])
     names(NodesDF) <- c("name")
-
+    
+    # add node group if specified
+    if (is.character(NodeGroup)){
+      NodesDF$group <- Nodes[, NodeGroup]
+    }
+    
+    if (is.character(LinkGroup)){
+      LinksDF$group <- Links[, LinkGroup]
+    }
+    
     # create options
     options = list(
         NodeID = NodeID,
+        NodeGroup = NodeGroup,
+        LinkGroup = LinkGroup,
         colourScale = colourScale,
         fontSize = fontSize,
         fontFamily = fontFamily,

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -43,6 +43,31 @@ HTMLWidgets.widget({
         var height = el.offsetHeight;
 
         var color = eval(options.colourScale);
+        
+        var color_node = function color_node(d){
+          if (d.group){
+            return color(d.group.replace(/ .*/, ""));
+          } else {
+            return "#cccccc";
+          }
+        }
+        
+        var color_link = function color_link(d){
+          if (d.group){
+            return color(d.group.replace(/ .*/, ""));
+          } else {
+            return "#000000";
+          }
+        }
+        
+        var opacity_link = function opacity_link(d){
+          if (d.group){
+            return 0.7;
+          } else {
+            return 0.2;
+          }
+        }
+
 
         var formatNumber = d3.format(",.0f"),
         format = function(d) { return formatNumber(d); }
@@ -71,16 +96,16 @@ HTMLWidgets.widget({
             .attr("d", path)
             .style("stroke-width", function(d) { return Math.max(1, d.dy); })
             .style("fill", "none")
-            .style("stroke", "#000")
-            .style("stroke-opacity", 0.2)
+            .style("stroke", color_link)
+            .style("stroke-opacity", opacity_link)
             .sort(function(a, b) { return b.dy - a.dy; })
             .on("mouseover", function(d) {
                 d3.select(this)
-                .style("stroke-opacity", 0.5);
+                .style("stroke-opacity", function(d){return opacity_link(d) + 0.3});
             })
             .on("mouseout", function(d) {
                 d3.select(this)
-                .style("stroke-opacity", 0.2);
+                .style("stroke-opacity", opacity_link);
             });
 
         // draw nodes
@@ -104,7 +129,7 @@ HTMLWidgets.widget({
             .attr("height", function(d) { return d.dy; })
             .attr("width", sankey.nodeWidth())
             .style("fill", function(d) {
-                return d.color = color(d.name.replace(/ .*/, "")); })
+                return d.color = color_node(d); })
             .style("stroke", function(d) { return d3.rgb(d.color).darker(2); })
             .style("opacity", 0.9)
             .style("cursor", "move")

--- a/man/sankeyNetwork.Rd
+++ b/man/sankeyNetwork.Rd
@@ -8,9 +8,10 @@ D3.js was created by Michael Bostock. See \url{http://d3js.org/} and, more
 specifically for Sankey diagrams \url{http://bost.ocks.org/mike/sankey/}.
 }
 \usage{
-sankeyNetwork(Links, Nodes, Source, Target, Value, NodeID, height = NULL,
-  width = NULL, units = "", colourScale = JS("d3.scale.category20()"),
-  fontSize = 7, fontFamily = NULL, nodeWidth = 15, nodePadding = 10)
+sankeyNetwork(Links, Nodes, Source, Target, Value, NodeID, NodeGroup = NodeID,
+  LinkGroup = NULL, height = NULL, width = NULL, units = "",
+  colourScale = JS("d3.scale.category20()"), fontSize = 7,
+  fontFamily = NULL, nodeWidth = 15, nodePadding = 10)
 }
 \arguments{
 \item{Links}{a data frame object with the links between the nodes. It should
@@ -34,6 +35,12 @@ frame for how far away the nodes are from one another.}
 
 \item{NodeID}{character string specifying the node IDs in the \code{Nodes}
 data frame.}
+
+\item{NodeGroup}{character string specifying the node groups in the
+\code{Nodes}. Used to color the nodes in the network.}
+
+\item{LinkGroup}{character string specifying the groups in the
+\code{Links}. Used to color the links in the network.}
 
 \item{height}{numeric height for the network graph's frame area in pixels.}
 


### PR DESCRIPTION
Dear Christopher,

Thanks for your wonderful package. I have added NodeGroup and LinkGroup parameters to sankeyNetwork. These parameters allow colourising the links in a network. Links (or nodes) with the same group will be assigned the same colour. Default behaviour is identical to current function: NodeGroup will be identical to NodeID and use that for colourising nodes.

A code example:
```R
energy <- jsonlite::fromJSON("JSONdata/energy.json")

# add group column to links based on first word of node name. 
# (same strategy as bostock code, but now on links...)
energy$links$energy_type <- sub(" .*","",energy$nodes[energy$links$source + 1, "name"])
sankeyNetwork( 
               Links = energy$links, Nodes = energy$nodes, Source = "source"
             , Target = "target", Value = "value", NodeID = "name", 
             , LinkGroup = "energy_type", NodeGroup = NULL, nodeWidth = 5
             )
```
Resulting in: 
![sankey_links_colours](https://cloud.githubusercontent.com/assets/542492/10044816/0c718eb6-61fe-11e5-9519-ae89bfdacd90.jpeg)

Possible further improvements:

- explicit colour specification for groups/types
- currently both NodeGroup and LinkGroup share the same color function, maybe a user should specify both. However I think that most people will colour either nodes or links.

Best,

Edwin
