### PR TITLE
make diagonalNetwork and radialNetwork responsive (sort-of)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: D3 JavaScript Network Graphs from R
 Description: Creates 'D3' 'JavaScript' network, tree, dendrogram, and Sankey
     graphs from 'R'.
-Version: 0.2.3
-Date: 2015-09-30
+Version: 0.2.4
+Date: 2015-10-01
 Authors@R: c(
     person("Christopher", "Gandrud", email = "christopher.gandrud@gmail.com",
     role = c("aut", "cre")),

--- a/NEWS
+++ b/NEWS
@@ -1,15 +1,21 @@
 # All changes to networkD3 are documented here.
 
+## Version 0.2.4
+
+- More robust margin argument for `diagonalNetwork` and `radialNetwork` allows for a single value or specification of `top`, `right`, `bottom`, and `left` by named `vector` or `list`
+
+- Responsive sizing using the `viewBox` attribute of `svg` for `diagonalNetwork` and `radialNetwork` should allow for fitting in the container with no fiddling
+
 ## Version 0.2.3
 
-  - Internal improvements to reduce dependencies: longer depends on RCurl, 
-  plyr, and rjson.
-  
-  - Updated examples: 
-    + Using jsonlite makes JSONtoDF obsolete with the `fromJSON` function.
-    + All Github data links now use the CDN link from 
-    [rawgit](https://rawgit.com/), so the examples  should be more inline with 
-    Github raw policies
+- Internal improvements to reduce dependencies: longer depends on RCurl, 
+plyr, and rjson.
+
+- Updated examples: 
+  + Using jsonlite makes JSONtoDF obsolete with the `fromJSON` function.
+  + All Github data links now use the CDN link from 
+  [rawgit](https://rawgit.com/), so the examples  should be more inline with 
+  Github raw policies
 
 ## Version 0.2.2
 

--- a/R/diagonalNetwork.R
+++ b/R/diagonalNetwork.R
@@ -17,8 +17,12 @@
 #' be before they are clicked. Multiple formats supported (e.g. hexadecimal).
 #' @param opacity numeric value of the proportion opaque you would like the
 #' graph elements to be.
-#' @param margin integer value of the plot margin. Set the margin
-#' appropriately to accomodate long text labels.
+#' @param margin an integer or a named \code{list}/\code{vector} of integers
+#' for the plot margins. If using a named \code{list}/\code{vector},
+#' the positions \code{top}, \code{right}, \code{bottom}, \code{left}
+#' are valid.  If a single integer is provided, then the value will be
+#' assigned to the right margin. Set the margin appropriately
+#' to accomodate long text labels.
 #'
 #'
 #' @examples
@@ -101,25 +105,7 @@ diagonalNetwork <- function(
       stop("List must be a list object.")
     root <- List
     
-    # margin can be either a single value or a list with any of
-    #    top, right, bottom, left
-    # if margin is a single value, then we will stick
-    #    with the original behavior of networkD3 and make it right
-    if(!is.null(margin) && length(margin) == 1){
-      margin <- list(
-        top = NULL,
-        right = margin,
-        bottom = NULL,
-        left = NULL
-      )
-    }
-    # if margin is a list, then  use the values supplied with NULL as default
-    if(!is.null(margin) && length(margin) > 1){
-      margin <- modifyList(
-        list(top = NULL, right = NULL, bottom = NULL, left = NULL),
-        margin
-      )
-    }
+    margin <- margin_handler(margin)
 
     # create options
     options = list(

--- a/R/diagonalNetwork.R
+++ b/R/diagonalNetwork.R
@@ -94,12 +94,32 @@ diagonalNetwork <- function(
                           nodeStroke = "steelblue",
                           textColour = "#111",
                           opacity = 0.9,
-                          margin = 0)
+                          margin = NULL)
 {
     # validate input
     if (!is.list(List))
       stop("List must be a list object.")
     root <- List
+    
+    # margin can be either a single value or a list with any of
+    #    top, right, bottom, left
+    # if margin is a single value, then we will stick
+    #    with the original behavior of networkD3 and make it right
+    if(!is.null(margin) && length(margin) == 1){
+      margin <- list(
+        top = NULL,
+        right = margin,
+        bottom = NULL,
+        left = NULL
+      )
+    }
+    # if margin is a list, then  use the values supplied with NULL as default
+    if(!is.null(margin) && length(margin) > 1){
+      margin <- modifyList(
+        list(top = NULL, right = NULL, bottom = NULL, left = NULL),
+        margin
+      )
+    }
 
     # create options
     options = list(

--- a/R/radialNetwork.R
+++ b/R/radialNetwork.R
@@ -17,8 +17,12 @@
 #' be before they are clicked. Multiple formats supported (e.g. hexadecimal).
 #' @param opacity numeric value of the proportion opaque you would like the
 #' graph elements to be.
-#' @param margin integer value of the plot margin. Set the margin
-#' appropriately to accomodate long text labels.
+#' @param margin an integer or a named \code{list}/\code{vector} of integers
+#' for the plot margins. If using a named \code{list}/\code{vector},
+#' the positions \code{top}, \code{right}, \code{bottom}, \code{left}
+#' are valid.  If a single integer is provided, then the value will be
+#' assigned to the right margin. Set the margin appropriately
+#' to accomodate long text labels.
 #'
 #'
 #' @examples
@@ -94,12 +98,14 @@ radialNetwork <- function(
                           nodeStroke = "steelblue",
                           textColour = "#111",
                           opacity = 0.9,
-                          margin = 0)
+                          margin = NULL)
 {
     # validate input
     if (!is.list(List))
       stop("List must be a list object.")
     root <- List
+    
+    margin <- margin_handler(margin)
 
     # create options
     options = list(

--- a/R/utils.R
+++ b/R/utils.R
@@ -59,3 +59,42 @@ toJSONarray <- function(dtf){
 read_file <- function(doc, ...){
   paste(readLines(doc, ...), collapse = '\n')
 }
+
+
+#' Utility function to handle margins
+#' @param margin an \code{integer}, a named \code{vector} of integers,
+#'    or a named \code{list} of integers specifying the margins
+#'    (top, right, bottom, and left)
+#'    in \code{px}/\code{pixels} for our htmlwidget.  If only a single
+#'    \code{integer} is provided, then the value will be assumed to be 
+#'    the \code{right} margin.
+#' @return named \code{list} with top, right, bottom, left margins
+#' @noRd
+margin_handler <- function(margin){
+  # margin can be either a single value or a list with any of
+  #    top, right, bottom, left
+  # if margin is a single value, then we will stick
+  #    with the original behavior of networkD3 and use it for the right margin
+  if(!is.null(margin) && length(margin) == 1 && is.null(names(margin))){
+    margin <- list(
+      top = NULL,
+      right = margin,
+      bottom = NULL,
+      left = NULL
+    )
+  } else if(!is.null(margin)){
+    # if margin is a named vector then convert to list
+    if(!is.list(margin) && !is.null(names(margin))){
+      margin <- as.list(margin)
+    }
+    # if we are here then margin should be a list and
+    #   we will use the values supplied with NULL as default
+    margin <- modifyList(
+      list(top = NULL, right = NULL, bottom = NULL, left = NULL),
+      margin
+    )
+  } else {
+    # if margin is null, then make it a list of nulls for each position
+    margin <- list(top = NULL, right = NULL, bottom = NULL, left = NULL)
+  } 
+}

--- a/inst/htmlwidgets/diagonalNetwork.js
+++ b/inst/htmlwidgets/diagonalNetwork.js
@@ -122,12 +122,12 @@ HTMLWidgets.widget({
             s.selectAll('.node text')[0].map(function(d){
               return d.getBoundingClientRect().left
             })
-          ) - margin.left,
+          ) - s.node().getBoundingClientRect().left - margin.right,
           d3.min(
             s.selectAll('.node text')[0].map(function(d){
               return d.getBoundingClientRect().top
             })
-          ) - margin.top,
+          ) - s.node().getBoundingClientRect().top - margin.top,
           d3.max(
             s.selectAll('.node text')[0].map(function(d){
               return d.getBoundingClientRect().right

--- a/inst/htmlwidgets/diagonalNetwork.js
+++ b/inst/htmlwidgets/diagonalNetwork.js
@@ -119,29 +119,35 @@ HTMLWidgets.widget({
         "viewBox",
         [
           d3.min(
-            s.selectAll("text")[0].map(function(d){
-              return d.__data__.y - (d.getBBox().width - d.getBBox().x);
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().left
             })
-          ),
+          ) - margin.left,
           d3.min(
-            s.selectAll("text")[0].map(function(d){
-              return d.__data__.x - d.getBBox().height;
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().top
             })
-          ),
+          ) - margin.top,
           d3.max(
-            s.selectAll("text")[0].map(function(d){
-              return d.__data__.y + (d.getBBox().width + d.getBBox().x);
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().right
             })
-          ) - d3.min(
-            s.selectAll("text")[0].map(function(d){
-              return d.__data__.y - (d.getBBox().width - d.getBBox().x);
+          ) -
+          d3.min(
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().left
             })
           ) + margin.left + margin.right,
           d3.max(
-            s.selectAll("text")[0].map(function(d){
-              return d.__data__.x + d.getBBox().height;
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().bottom
             })
-          ) + margin.top + margin.bottom       
+          ) -
+          d3.min(
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().top
+            })
+          ) + margin.top + margin.bottom
         ].join(",")
       );        
 

--- a/inst/htmlwidgets/diagonalNetwork.js
+++ b/inst/htmlwidgets/diagonalNetwork.js
@@ -45,7 +45,7 @@ HTMLWidgets.widget({
         margin[ky] = x.options.margin[ky];
       }
       // set the margin on the svg with css style
-      s.style(["margin-",ky].join("-"), margin[ky]);
+      s.style(["margin",ky].join("-"), margin[ky]);
     });
       
     

--- a/inst/htmlwidgets/diagonalNetwork.js
+++ b/inst/htmlwidgets/diagonalNetwork.js
@@ -34,9 +34,21 @@ HTMLWidgets.widget({
 
     var s = d3.select(el).selectAll("svg");
     
-    s.attr("margin", x.options.margin);
-    var margin = {top: 20, right: 20 + parseInt(s.attr("margin")), bottom: 20, 
-      left: 20};
+    // margin handling
+    //   set our default margin to be 20
+    //   will override with x.options.margin if provided
+    var margin = {top: 20, right: 20, bottom: 20, left: 20};
+    //   go through each key of x.options.margin
+    //   use this value if provided from the R side
+    Object.keys(x.options.margin).map(function(ky){
+      if(x.options.margin[ky] !== null) {
+        margin[ky] = x.options.margin[ky];
+      }
+      // set the margin on the svg with css style
+      s.style(["margin-",ky].join("-"), margin[ky]);
+    });
+      
+    
     width = s.attr("width") - margin.right - margin.left;
     height = s.attr("height") - margin.top - margin.bottom;
     

--- a/inst/htmlwidgets/radialNetwork.js
+++ b/inst/htmlwidgets/radialNetwork.js
@@ -123,12 +123,12 @@ HTMLWidgets.widget({
             s.selectAll('.node text')[0].map(function(d){
               return d.getBoundingClientRect().left
             })
-          ) - margin.left,
+          ) - s.node().getBoundingClientRect().left - margin.right,
           d3.min(
             s.selectAll('.node text')[0].map(function(d){
               return d.getBoundingClientRect().top
             })
-          ) - margin.top,
+          ) - s.node().getBoundingClientRect().top - margin.top,
           d3.max(
             s.selectAll('.node text')[0].map(function(d){
               return d.getBoundingClientRect().right

--- a/inst/htmlwidgets/radialNetwork.js
+++ b/inst/htmlwidgets/radialNetwork.js
@@ -44,7 +44,7 @@ HTMLWidgets.widget({
         margin[ky] = x.options.margin[ky];
       }
       // set the margin on the svg with css style
-      s.style(["margin-",ky].join("-"), margin[ky]);
+      s.style(["margin",ky].join("-"), margin[ky]);
     });
 
     var diameter = Math.min(

--- a/inst/htmlwidgets/radialNetwork.js
+++ b/inst/htmlwidgets/radialNetwork.js
@@ -5,10 +5,14 @@ HTMLWidgets.widget({
 
   initialize: function(el, width, height) {
 
-    var diameter = Math.min(parseInt(width),parseInt(height));
+    var diameter = Math.min(
+      el.getBoundingClientRect().width,
+      el.getBoundingClientRect().height
+    );
+    
     d3.select(el).append("svg")
-      .attr("width", width)
-      .attr("height", height)
+      .style("width", "100%")
+      .style("height", "100%")
       .append("g")
       .attr("transform", "translate(" + diameter / 2 + "," + diameter / 2 + ")"
                          + " scale("+diameter/800+","+diameter/800+")");
@@ -17,6 +21,8 @@ HTMLWidgets.widget({
   },
 
   resize: function(el, width, height, tree) {
+    // resize now handled by svg viewBox attribute
+    /*
     var diameter = Math.min(parseInt(width),parseInt(height));
     var s = d3.select(el).selectAll("svg");
     s.attr("width", width).attr("height", height);
@@ -24,6 +30,7 @@ HTMLWidgets.widget({
     var svg = d3.select(el).selectAll("svg").select("g");
     svg.attr("transform", "translate(" + diameter / 2 + "," + diameter / 2 + ")"
                          + " scale("+diameter/800+","+diameter/800+")");
+    */
 
   },
 
@@ -44,12 +51,13 @@ HTMLWidgets.widget({
         margin[ky] = x.options.margin[ky];
       }
       // set the margin on the svg with css style
-      s.style(["margin",ky].join("-"), margin[ky]);
+      // commenting this out since not correct
+      //s.style(["margin",ky].join("-"), margin[ky]);
     });
 
     var diameter = Math.min(
-      parseInt(s.attr("width")) - margin.right - margin.left,
-      parseInt(s.attr("height")) - margin.top - margin.bottom
+      s.node().getBoundingClientRect().width - margin.right - margin.left,
+      s.node().getBoundingClientRect().height - margin.top - margin.bottom
     );
 
     tree.size([360, diameter/2])
@@ -59,7 +67,7 @@ HTMLWidgets.widget({
     s.attr("pointer-events", "all").selectAll("*").remove();
     s.append("g")
      .attr("transform", "translate(" + diameter / 2 + "," + diameter / 2 + ")"
-                         + " scale("+diameter/800+","+diameter/800+")");
+                         + " scale("+1+","+1+")");
 
     var svg = d3.select(el).selectAll("g");
 
@@ -106,6 +114,44 @@ HTMLWidgets.widget({
         .style("opacity", x.options.opacity)
         .style("fill", x.options.textColour)
         .text(function(d) { return d.name; });
+        
+    // adjust viewBox to fit the bounds of our tree
+    s.attr(
+        "viewBox",
+        [
+          d3.min(
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().left
+            })
+          ) - margin.left,
+          d3.min(
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().top
+            })
+          ) - margin.top,
+          d3.max(
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().right
+            })
+          ) -
+          d3.min(
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().left
+            })
+          ) + margin.left + margin.right,
+          d3.max(
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().bottom
+            })
+          ) -
+          d3.min(
+            s.selectAll('.node text')[0].map(function(d){
+              return d.getBoundingClientRect().top
+            })
+          ) + margin.top + margin.bottom
+        ].join(",")
+      );        
+
 
     // mouseover event handler
     function mouseover() {

--- a/inst/htmlwidgets/radialNetwork.js
+++ b/inst/htmlwidgets/radialNetwork.js
@@ -32,9 +32,27 @@ HTMLWidgets.widget({
     // JSON array with the d3Tree root data
 
     var s = d3.select(el).selectAll("svg");
-    var diameter = Math.min(parseInt(s.attr("width")),parseInt(s.attr("height")));
-    s.attr("margin", x.options.margin);
-    tree.size([360, diameter/2 - parseInt(s.attr("margin"))])
+
+    // margin handling
+    //   set our default margin to be 20
+    //   will override with x.options.margin if provided
+    var margin = {top: 20, right: 20, bottom: 20, left: 20};
+    //   go through each key of x.options.margin
+    //   use this value if provided from the R side
+    Object.keys(x.options.margin).map(function(ky){
+      if(x.options.margin[ky] !== null) {
+        margin[ky] = x.options.margin[ky];
+      }
+      // set the margin on the svg with css style
+      s.style(["margin-",ky].join("-"), margin[ky]);
+    });
+
+    var diameter = Math.min(
+      parseInt(s.attr("width")) - margin.right - margin.left,
+      parseInt(s.attr("height")) - margin.top - margin.bottom
+    );
+
+    tree.size([360, diameter/2])
         .separation(function(a, b) { return (a.parent == b.parent ? 1 : 2) / a.depth; });
 
     // select the svg group element and remove existing children


### PR DESCRIPTION
This pull is a little more intrusive on the current behavior of `diagonalNetwork` and `radialNetwork`, but I think it wisely lets the [`viewBox`](http://sarasoueidan.com/blog/svg-coordinate-systems/) attribute of `SVG` handle sizing and resizing.  It seems the `resize` method already is a little broken, so I don't think this causes any more damage.  Using this approach also insures that the diagram fits within the `htmlwidget` container `div`, so a `R` user does not need to fiddle with `margins` unless desired.

At a minimum, I think this should exist as an argument to toggle on or off, but I'm very comfortable making this the default behavior especially given @christophergandrud focus on simplicity.
![networkd3 responsive](https://cloud.githubusercontent.com/assets/837910/10200739/b4687f70-676d-11e5-9cac-9669b87287be.gif)
