### PR TITLE
sankey - cycles, margins, and better sizing/fitting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: D3 JavaScript Network Graphs from R
 Description: Creates 'D3' 'JavaScript' network, tree, dendrogram, and Sankey
     graphs from 'R'.
-Version: 0.2.5
-Date: 2015-10-01
+Version: 0.2.6
+Date: 2015-10-08
 Authors@R: c(
     person("Christopher", "Gandrud", email = "christopher.gandrud@gmail.com",
     role = c("aut", "cre")),

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,13 @@
 # All changes to networkD3 are documented here.
 
+## Version 0.2.6
+
+- `sankeyNetwork` fully supports cycles
+- `sankeyNetwork` gets same responsive sizing and better fitting introduced
+in 0.2.4 for `diagonalNetwork` and `radialNetwork`
+- `sankeyNetwork` gets same full margin control introduced
+in 0.2.4 for `diagonalNetwork` and `radialNetwork`
+
 ## Version 0.2.5
 
 - Added `chordDiagram` to show directed relationships among entities

--- a/R/chordNetwork.R
+++ b/R/chordNetwork.R
@@ -30,7 +30,7 @@
 #'                             2868,  6171,  8045, 6907),
 #'                             nrow = 4)
 #'                             
-#' chordNetwork(data = hairColourData, 
+#' chordNetwork(Data = hairColourData, 
 #'              width = 500, 
 #'              height = 500,
 #'              colourScale = c("#000000", 
@@ -47,7 +47,7 @@
 #'
 #' @export
 #'
-chordNetwork <- function(data,
+chordNetwork <- function(Data,
                          height = 500,
                          width = 500,
                          initialOpacity = 0.8,
@@ -93,34 +93,34 @@ chordNetwork <- function(data,
     label_distance = labelDistance
   )
   
-  if (!is.matrix(data) && !is.data.frame(data))
+  if (!is.matrix(Data) && !is.data.frame(Data))
   {
     stop("Data must be of type matrix or data frame")
   }
   
-  if (nrow(data) != ncol(data))
+  if (nrow(Data) != ncol(Data))
   {
     stop(paste("Data must have the same number of rows and columns; given ",
-               nrow(data),
+               nrow(Data),
                "rows and",
-               ncol(data),
+               ncol(Data),
                "columns",
                sep = " "))
   }
   
-  if(length(labels)!=0 && length(labels)!=ncol(data)){
+  if(length(labels)!=0 && length(labels)!=ncol(Data)){
     stop(paste("Length of labels vector should be the same as the number of rows"))
   }
   
-  if (is.data.frame(data))
+  if (is.data.frame(Data))
   {
-    data = data.matrix(data)
+    Data = data.matrix(Data)
   }
   
   # create widget
   htmlwidgets::createWidget(
     name = "chordNetwork",
-    x = list(matrix = data, options = options),
+    x = list(matrix = Data, options = options),
     width = width,
     height = height,
     htmlwidgets::sizingPolicy(viewer.suppress = TRUE,

--- a/R/chordNetwork.R
+++ b/R/chordNetwork.R
@@ -17,6 +17,10 @@
 #' @param fontSize numeric font size in pixels for the node text labels.
 #' @param fontFamily font family for the node text labels.
 #' @param labels vector containing labels of the categories
+#' @param useTicks integer number of ticks on the radial axis.
+#'        The default is `0` which means no ticks will be drawn.
+#' @param labelDistance integer distance in pixels (px) between
+#'        text labels and outer radius.  The default is `30`.
 #'
 #'
 #' @examples

--- a/R/diagonalNetwork.R
+++ b/R/diagonalNetwork.R
@@ -41,8 +41,8 @@
 #'
 #' #### Create a tree dendrogram from an R hclust object
 #' hc <- hclust(dist(USArrests), "ave")
-#' diagonalNetwork(as.diagonalNetwork(hc))
-#' diagonalNetwork(as.diagonalNetwork(hc), fontFamily = "cursive")
+#' diagonalNetwork(as.radialNetwork(hc))
+#' diagonalNetwork(as.radialNetwork(hc), fontFamily = "cursive")
 #'
 #' #### Create tree from a hierarchical R list
 #' For an alternative structure see: http://stackoverflow.com/a/30747323/1705044

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -17,8 +17,6 @@
 #' @param NodeID character string specifying the node IDs in the \code{Nodes}
 #' data frame.
 #' @param units character string describing physical units (if any) for Value
-#' @param height numeric height for the network graph's frame area in pixels.
-#' @param width numeric width for the network graph's frame area in pixels.
 #' @param colourScale character string specifying the categorical colour
 #' scale for the nodes. See
 #' \url{https://github.com/mbostock/d3/wiki/Ordinal-Scales}.
@@ -26,7 +24,15 @@
 #' @param fontFamily font family for the node text labels.
 #' @param nodeWidth numeric width of each node.
 #' @param nodePadding numeric essentially influences the width height.
-#'
+#' @param margin an integer or a named \code{list}/\code{vector} of integers
+#' for the plot margins. If using a named \code{list}/\code{vector},
+#' the positions \code{top}, \code{right}, \code{bottom}, \code{left}
+#' are valid.  If a single integer is provided, then the value will be
+#' assigned to the right margin. Set the margin appropriately
+#' to accomodate long text labels.
+#' @param height numeric height for the network graph's frame area in pixels.
+#' @param width numeric width for the network graph's frame area in pixels.
+#' 
 #' @examples
 #' \dontrun{
 #' # Recreate Bostock Sankey diagram: http://bost.ocks.org/mike/sankey/
@@ -53,14 +59,16 @@ sankeyNetwork <- function(Links,
                           Target,
                           Value,
                           NodeID,
-                          height = NULL,
-                          width = NULL,
                           units = "",
                           colourScale = JS("d3.scale.category20()"),
                           fontSize = 7,
                           fontFamily = NULL,
                           nodeWidth = 15,
-                          nodePadding = 10)
+                          nodePadding = 10,
+                          margin = NULL,
+                          height = NULL,
+                          width = NULL
+                         )
 {
     # Hack for UI consistency. Think of improving.
     colourScale <- as.character(colourScale)
@@ -92,6 +100,8 @@ sankeyNetwork <- function(Links,
     if(missing(NodeID)) NodeID = 1
     NodesDF <- data.frame(Nodes[, NodeID])
     names(NodesDF) <- c("name")
+    
+    margin <- margin_handler(margin)    
 
     # create options
     options = list(
@@ -101,7 +111,8 @@ sankeyNetwork <- function(Links,
         fontFamily = fontFamily,
         nodeWidth = nodeWidth,
         nodePadding = nodePadding,
-        units = units
+        units = units,
+        margin = margin
     )
 
     # create widget

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # D3 JavaScript Network Graphs from R
 
-Version 0.2.5 [![Build Status](https://travis-ci.org/christophergandrud/networkD3.svg?branch=master)](https://travis-ci.org/christophergandrud/networkD3) ![CRAN Downloads](http://cranlogs.r-pkg.org/badges/last-month/networkD3)
+Version 0.2.6 [![Build Status](https://travis-ci.org/christophergandrud/networkD3.svg?branch=master)](https://travis-ci.org/christophergandrud/networkD3) ![CRAN Downloads](http://cranlogs.r-pkg.org/badges/last-month/networkD3)
 
 This is a port of Christopher Gandrud's
 [d3Network](http://christophergandrud.github.io/d3Network/) package to the

--- a/inst/examples/examples.R
+++ b/inst/examples/examples.R
@@ -89,6 +89,27 @@ sankeyNetwork(Links = Energy$links, Nodes = Energy$nodes, Source = "source",
               Target = "target", Value = "value", NodeID = "name",
               fontSize = 12, nodeWidth = 30, fontFamily = "monospace")
 
+# as of 0.2.6 sankeyNetwork supports cycles
+# simple network with cycle 5 -> 0
+net_cycles <- list(
+  links = data.frame(
+    source = c(0,0,0,1,1,5),
+    target = c(1,2,3,4,5,0),
+    value = 10
+  ),
+  nodes = data.frame(
+    name = letters[1:6]
+  )
+)
+
+# notice how few arguments we need now
+# some output but not the nice output I expect
+sankeyNetwork(
+  net_cycles$links,
+  net_cycles$nodes,
+  Value = "value"
+)
+
 
 # radialNetwork
 Flare <- jsonlite::fromJSON(

--- a/inst/htmlwidgets/lib/sankey.js
+++ b/inst/htmlwidgets/lib/sankey.js
@@ -61,17 +61,34 @@ d3.sankey = function() {
     var curvature = .5;
 
     function link(d) {
-      var x0 = d.source.x + d.source.dx,
-          x1 = d.target.x,
-          xi = d3.interpolateNumber(x0, x1),
-          x2 = xi(curvature),
-          x3 = xi(1 - curvature),
-          y0 = d.source.y + d.sy + d.dy / 2,
-          y1 = d.target.y + d.ty + d.dy / 2;
-      return "M" + x0 + "," + y0
-           + "C" + x2 + "," + y0
-           + " " + x3 + "," + y1
-           + " " + x1 + "," + y1;
+      var xs = d.source.x + d.source.dx,
+          xt = d.target.x,
+          xi = d3.interpolateNumber(xs, xt),
+          xsc = xi(curvature),
+          xtc = xi(1 - curvature),
+          ys = d.source.y + d.sy + d.dy / 2,
+          yt = d.target.y + d.ty + d.dy / 2;
+
+      if (!d.cycleBreaker) {
+        return "M" + xs + "," + ys
+             + "C" + xsc + "," + ys
+             + " " + xtc + "," + yt
+             + " " + xt + "," + yt;
+      } else {
+        var xdelta = (1.5 * d.dy + 0.05 * Math.abs(xs - xt));
+        xsc = xs + xdelta;
+        xtc = xt - xdelta;
+        var xm = xi(0.5);
+        var ym = d3.interpolateNumber(ys, yt)(0.5);
+        var ydelta = (2 * d.dy + 0.1 * Math.abs(xs - xt) + 0.1 * Math.abs(ys - yt)) * (ym < (size[1] / 2) ? -1 : 1);
+        return "M" + xs + "," + ys
+             + "C" + xsc + "," + ys
+             + " " + xsc + "," + (ys + ydelta)
+             + " " + xm + "," + (ym + ydelta)
+             + "S" + xtc + "," + yt
+             + " " + xt + "," + yt;
+
+      }
     }
 
     link.curvature = function(_) {
@@ -129,13 +146,22 @@ d3.sankey = function() {
         node.x = x;
         node.dx = nodeWidth;
         node.sourceLinks.forEach(function(link) {
-          if (nextNodes.indexOf(link.target) < 0) {
+          if (nextNodes.indexOf(link.target) < 0 && !link.cycleBreaker) {
             nextNodes.push(link.target);
           }
         });
       });
-      remainingNodes = nextNodes;
-      ++x;
+      if (nextNodes.length == remainingNodes.length) {
+        // There must be a cycle here. Let's search for a link that breaks it.
+        findAndMarkCycleBreaker(nextNodes);
+        // Start over.
+        // TODO: make this optional?
+        return computeNodeBreadths();
+      }
+      else {
+        remainingNodes = nextNodes;
+        ++x;
+      }
     }
 
     // Optionally move pure sinks always to the right.
@@ -145,6 +171,57 @@ d3.sankey = function() {
 
     scaleNodeBreadths((size[0] - nodeWidth) / (x - 1));
   }
+
+  // Find a link that breaks a cycle in the graph (if any).
+  function findAndMarkCycleBreaker(nodes) {
+  // Go through all nodes from the given subset and traverse links searching for cycles.
+    var link;
+    for (var n=nodes.length - 1; n >= 0; n--) {
+      link = depthFirstCycleSearch(nodes[n], []);
+      if (link) {
+        return link;
+      }
+    }
+
+    // Depth-first search to find a link that is part of a cycle.
+    function depthFirstCycleSearch(cursorNode, path) {
+      var target, link;
+      for (var n = cursorNode.sourceLinks.length - 1; n >= 0; n--) {
+        link = cursorNode.sourceLinks[n];
+        if (link.cycleBreaker) {
+          // Skip already known cycle breakers.
+          continue;
+        }
+
+        // Check if target of link makes a cycle in current path.
+        target = link.target;
+        for (var l = 0; l < path.length; l++) {
+          if (path[l].source == target) {
+            // We found a cycle. Search for weakest link in cycle
+            var weakest = link;
+            for (; l < path.length; l++) {
+              if (path[l].value < weakest.value) {
+                weakest = path[l];
+              }
+            }
+            // Mark weakest link as (known) cycle breaker and abort search.
+            weakest.cycleBreaker = true;
+            return weakest;
+          }
+        }
+
+        // Recurse deeper.
+        path.push(link);
+        link = depthFirstCycleSearch(target, path);
+        path.pop();
+        // Stop further search if we found a cycle breaker.
+        if (link) {
+          return link;
+        }
+      }
+    }
+  }
+
 
   function moveSourcesRight() {
     nodes.forEach(function(node) {

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -135,6 +135,45 @@ HTMLWidgets.widget({
             .filter(function(d) { return d.x < width / 2; })
             .attr("x", 6 + sankey.nodeWidth())
             .attr("text-anchor", "start");
+            
+            
+        // adjust viewBox to fit the bounds of our tree
+        svg.attr(
+            "viewBox",
+            [
+              d3.min(
+                svg.selectAll('*')[0].map(function(d){
+                  return d.getBoundingClientRect().left
+                })
+              ) - svg.node().getBoundingClientRect().left,
+              d3.min(
+                svg.selectAll('*')[0].map(function(d){
+                  return d.getBoundingClientRect().top
+                })
+              ) - svg.node().getBoundingClientRect().top,
+              d3.max(
+                svg.selectAll('*')[0].map(function(d){
+                  return d.getBoundingClientRect().right
+                })
+              ) -
+              d3.min(
+                svg.selectAll('*')[0].map(function(d){
+                  return d.getBoundingClientRect().left
+                })
+              ),
+              d3.max(
+                svg.selectAll('*')[0].map(function(d){
+                  return d.getBoundingClientRect().bottom
+                })
+              ) -
+              d3.min(
+                svg.selectAll('*')[0].map(function(d){
+                  return d.getBoundingClientRect().top
+                })
+              )
+            ].join(",")
+          );        
+        
 
         function dragmove(d) {
             d3.select(this).attr("transform", "translate(" + d.x + "," +

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -7,8 +7,8 @@ HTMLWidgets.widget({
     initialize: function(el, width, height) {
 
         d3.select(el).append("svg")
-            .attr("width", width)
-            .attr("height", height + height * 0.05);
+            .style("width", "100%")
+            .style("height", "100%");
 
         return {
           sankey: d3.sankey(),
@@ -17,12 +17,13 @@ HTMLWidgets.widget({
     },
 
     resize: function(el, width, height, instance) {
-
+        /*  handle resizing now through the viewBox
         d3.select(el).select("svg")
             .attr("width", width)
             .attr("height", height + height * 0.05);
 
         this.renderValue(el, instance.x, instance);
+        */ 
     },
 
     renderValue: function(el, x, instance) {
@@ -37,10 +38,26 @@ HTMLWidgets.widget({
         // convert links and nodes data frames to d3 friendly format
         var links = HTMLWidgets.dataframeToD3(x.links);
         var nodes = HTMLWidgets.dataframeToD3(x.nodes);
+        
+    
+        // margin handling
+        //   set our default margin to be 20
+        //   will override with x.options.margin if provided
+        var margin = {top: 20, right: 20, bottom: 20, left: 20};
+        //   go through each key of x.options.margin
+        //   use this value if provided from the R side
+        Object.keys(x.options.margin).map(function(ky){
+          if(x.options.margin[ky] !== null) {
+            margin[ky] = x.options.margin[ky];
+          }
+          // set the margin on the svg with css style
+          // commenting this out since not correct
+          // s.style(["margin",ky].join("-"), margin[ky]);
+        });        
 
         // get the width and height
-        var width = el.getBoundingClientRect().width;
-        var height = el.getBoundingClientRect().height;
+        var width = el.getBoundingClientRect().width - margin.right - margin.left;
+        var height = el.getBoundingClientRect().height - margin.top - margin.bottom;
 
         var color = eval(options.colourScale);
 
@@ -56,9 +73,11 @@ HTMLWidgets.widget({
             .nodePadding(options.nodePadding)
             .layout(32);
 
-        // select the svg element and remove existing childern
-        var svg = d3.select(el).select("svg");
-        svg.selectAll("*").remove();
+        // select the svg element and remove existing children
+        d3.select(el).select("svg").selectAll("*").remove();
+        // append g for our container to transform by margin
+        var svg = d3.select(el).select("svg").append("g")
+            .attr("transform", "translate(" + margin.left + "," + margin.top + ")");;
 
         // draw path
         var path = sankey.link();
@@ -138,39 +157,40 @@ HTMLWidgets.widget({
             
             
         // adjust viewBox to fit the bounds of our tree
-        svg.attr(
+        var s = d3.select(svg[0][0].parentNode);
+        s.attr(
             "viewBox",
             [
               d3.min(
-                svg.selectAll('*')[0].map(function(d){
+                s.selectAll('*')[0].map(function(d){
                   return d.getBoundingClientRect().left
                 })
-              ) - svg.node().getBoundingClientRect().left,
+              ) - s.node().getBoundingClientRect().left - margin.right,
               d3.min(
-                svg.selectAll('*')[0].map(function(d){
+                s.selectAll('*')[0].map(function(d){
                   return d.getBoundingClientRect().top
                 })
-              ) - svg.node().getBoundingClientRect().top,
+              ) - s.node().getBoundingClientRect().top - margin.top,
               d3.max(
-                svg.selectAll('*')[0].map(function(d){
+                s.selectAll('*')[0].map(function(d){
                   return d.getBoundingClientRect().right
                 })
               ) -
               d3.min(
-                svg.selectAll('*')[0].map(function(d){
+                s.selectAll('*')[0].map(function(d){
                   return d.getBoundingClientRect().left
                 })
-              ),
+              )  + margin.left + margin.right,
               d3.max(
-                svg.selectAll('*')[0].map(function(d){
+                s.selectAll('*')[0].map(function(d){
                   return d.getBoundingClientRect().bottom
                 })
               ) -
               d3.min(
-                svg.selectAll('*')[0].map(function(d){
+                s.selectAll('*')[0].map(function(d){
                   return d.getBoundingClientRect().top
                 })
-              )
+              ) + margin.top + margin.bottom
             ].join(",")
           );        
         

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -39,8 +39,8 @@ HTMLWidgets.widget({
         var nodes = HTMLWidgets.dataframeToD3(x.nodes);
 
         // get the width and height
-        var width = el.offsetWidth;
-        var height = el.offsetHeight;
+        var width = el.getBoundingClientRect().width;
+        var height = el.getBoundingClientRect().height;
 
         var color = eval(options.colourScale);
 
@@ -66,8 +66,11 @@ HTMLWidgets.widget({
         // draw links
         var link = svg.selectAll(".link")
             .data(sankey.links())
-            .enter().append("path")
+
+        link.enter().append("path")
             .attr("class", "link")
+        
+        link
             .attr("d", path)
             .style("stroke-width", function(d) { return Math.max(1, d.dy); })
             .style("fill", "none")
@@ -82,11 +85,19 @@ HTMLWidgets.widget({
                 d3.select(this)
                 .style("stroke-opacity", 0.2);
             });
+            
+        // add backwards class to cycles
+        link.classed('backwards', function (d) { return d.target.x < d.source.x; });
+        
+        svg.selectAll(".link.backwards")
+            .style("stroke-dasharray","9,1")
+            .style("stroke","#402")
 
         // draw nodes
         var node = svg.selectAll(".node")
             .data(sankey.nodes())
-            .enter().append("g")
+            
+        node.enter().append("g")
             .attr("class", "node")
             .attr("transform", function(d) { return "translate(" +
                                             d.x + "," + d.y + ")"; })

--- a/man/chordNetwork.Rd
+++ b/man/chordNetwork.Rd
@@ -27,6 +27,9 @@ the strength of the link from group n to group m}
 \item{initialOpacity}{specify the opacity before the user mouses over
 the link}
 
+\item{useTicks}{integer number of ticks on the radial axis.
+The default is `0` which means no ticks will be drawn.}
+
 \item{colourScale}{specify the hexadecimal colours in which to display
 the different categories. If there are fewer colours than categories,
 the last colour is repeated as necessary (if \code{NULL} then defaults
@@ -40,6 +43,9 @@ on the outside of the graph}
 \item{fontFamily}{font family for the node text labels.}
 
 \item{labels}{vector containing labels of the categories}
+
+\item{labelDistance}{integer distance in pixels (px) between
+       text labels and outer radius.  The default is `30`.}
 }
 \description{
 Create Reingold-Tilford Tree network diagrams.

--- a/man/chordNetwork.Rd
+++ b/man/chordNetwork.Rd
@@ -7,7 +7,7 @@
 Mike Bostock: \url{https://github.com/mbostock/d3/wiki/Chord-Layout}.
 }
 \usage{
-chordNetwork(data, height = 500, width = 500, initialOpacity = 0.8,
+chordNetwork(Data, height = 500, width = 500, initialOpacity = 0.8,
   useTicks = 0, colourScale = c("#1f77b4", "#aec7e8", "#ff7f0e", "#ffbb78",
   "#2ca02c", "#98df8a", "#d62728", "#ff9896", "#9467bd", "#c5b0d5", "#8c564b",
   "#c49c94", "#e377c2", "#f7b6d2", "#7f7f7f", "#c7c7c7", "#bcbd22", "#dbdb8d",
@@ -15,6 +15,9 @@ chordNetwork(data, height = 500, width = 500, initialOpacity = 0.8,
   fontFamily = "sans-serif", labels = c(), labelDistance = 30)
 }
 \arguments{
+\item{Data}{A square matrix or data frame whose (n, m) entry represents
+the strength of the link from group n to group m}
+
 \item{height}{height for the network graph's frame area in pixels (if
 \code{NULL} then height is automatically determined based on context)}
 
@@ -37,9 +40,6 @@ on the outside of the graph}
 \item{fontFamily}{font family for the node text labels.}
 
 \item{labels}{vector containing labels of the categories}
-
-\item{Data}{A square matrix or data frame whose (n, m) entry represents
-the strength of the link from group n to group m}
 }
 \description{
 Create Reingold-Tilford Tree network diagrams.
@@ -55,7 +55,7 @@ hairColourData <- matrix(c(11975,  1951,  8010, 1013,
                             2868,  6171,  8045, 6907),
                             nrow = 4)
 
-chordNetwork(data = hairColourData,
+chordNetwork(Data = hairColourData,
              width = 500,
              height = 500,
              colourScale = c("#000000",

--- a/man/diagonalNetwork.Rd
+++ b/man/diagonalNetwork.Rd
@@ -69,8 +69,8 @@ diagonalNetwork(List = Flare, fontSize = 10, opacity = 0.9)
 
 #### Create a tree dendrogram from an R hclust object
 hc <- hclust(dist(USArrests), "ave")
-diagonalNetwork(as.diagonalNetwork(hc))
-diagonalNetwork(as.diagonalNetwork(hc), fontFamily = "cursive")
+diagonalNetwork(as.radialNetwork(hc))
+diagonalNetwork(as.radialNetwork(hc), fontFamily = "cursive")
 
 #### Create tree from a hierarchical R list
 For an alternative structure see: http://stackoverflow.com/a/30747323/1705044

--- a/man/sankeyNetwork.Rd
+++ b/man/sankeyNetwork.Rd
@@ -8,9 +8,10 @@ D3.js was created by Michael Bostock. See \url{http://d3js.org/} and, more
 specifically for Sankey diagrams \url{http://bost.ocks.org/mike/sankey/}.
 }
 \usage{
-sankeyNetwork(Links, Nodes, Source, Target, Value, NodeID, height = NULL,
-  width = NULL, units = "", colourScale = JS("d3.scale.category20()"),
-  fontSize = 7, fontFamily = NULL, nodeWidth = 15, nodePadding = 10)
+sankeyNetwork(Links, Nodes, Source, Target, Value, NodeID, units = "",
+  colourScale = JS("d3.scale.category20()"), fontSize = 7,
+  fontFamily = NULL, nodeWidth = 15, nodePadding = 10, margin = NULL,
+  height = NULL, width = NULL)
 }
 \arguments{
 \item{Links}{a data frame object with the links between the nodes. It should
@@ -35,10 +36,6 @@ frame for how far away the nodes are from one another.}
 \item{NodeID}{character string specifying the node IDs in the \code{Nodes}
 data frame.}
 
-\item{height}{numeric height for the network graph's frame area in pixels.}
-
-\item{width}{numeric width for the network graph's frame area in pixels.}
-
 \item{units}{character string describing physical units (if any) for Value}
 
 \item{colourScale}{character string specifying the categorical colour
@@ -52,6 +49,17 @@ scale for the nodes. See
 \item{nodeWidth}{numeric width of each node.}
 
 \item{nodePadding}{numeric essentially influences the width height.}
+
+\item{margin}{an integer or a named \code{list}/\code{vector} of integers
+for the plot margins. If using a named \code{list}/\code{vector},
+the positions \code{top}, \code{right}, \code{bottom}, \code{left}
+are valid.  If a single integer is provided, then the value will be
+assigned to the right margin. Set the margin appropriately
+to accomodate long text labels.}
+
+\item{height}{numeric height for the network graph's frame area in pixels.}
+
+\item{width}{numeric width for the network graph's frame area in pixels.}
 }
 \description{
 Create a D3 JavaScript Sankey diagram


### PR DESCRIPTION
When I wrote the post to announce `networkD3` version `0.2.4` I realized that I copied the wrong `sankey.js`.  As I was updating the sankey.js plugin, I thought I would add the same better margin argument and `viewBox` responsive fitting/resizing that we added in `0.2.4` for `diagonalNetwork` and `radialNetwork`.

So sorry I messed this up before the CRAN release. @christophergandrud, not sure when would be best to resubmit.  I did the CRAN check locally on Windows 7 with RStudio 3.2.2 and all passed.