### PR TITLE
Improved bounding box

### DIFF
--- a/inst/htmlwidgets/forceNetwork.js
+++ b/inst/htmlwidgets/forceNetwork.js
@@ -141,33 +141,20 @@ HTMLWidgets.widget({
       .style("opacity", options.opacityNoHover)
       .style("pointer-events", "none");
 
-    // Add the option for a bounded box
-    function nodeBoxX(d,width) {
-        if(options.bounded){
-            var dx = Math.max(nodeSize(d), Math.min(width - nodeSize(d), d.x));
-            return dx;
-        }else{
-            return d.x}
-    }
-    function nodeBoxY(d, height) {
-        if(options.bounded){
-            var dy = Math.max(nodeSize(d), Math.min(height - nodeSize(d), d.y));
-            return dy;
-        }else{
-            return d.y}
-    }
-
     function tick() {
+      node.attr("transform", function(d) {
+        if(options.bounded){ // adds bounding box
+            d.x = Math.max(nodeSize(d), Math.min(width - nodeSize(d), d.x));
+            d.y = Math.max(nodeSize(d), Math.min(height - nodeSize(d), d.y));
+        }
+        
+        return "translate(" + d.x + "," + d.y + ")"});
+        
       link
         .attr("x1", function(d) { return d.source.x; })
         .attr("y1", function(d) { return d.source.y; })
         .attr("x2", function(d) { return d.target.x; })
         .attr("y2", function(d) { return d.target.y; });
-
-      node
-        .attr("transform", function(d) {
-          return "translate(" + nodeBoxX(d,width) + "," + nodeBoxY(d,height) + ")";
-        });
     }
 
     function mouseover() {


### PR DESCRIPTION
Had to revisit this one. The current bounding box only bounds the nodes, but not the links. You could grab the whole graph off the screen. The intended graph behaviour example is [here](http://bl.ocks.org/mbostock/1129492). The minimal code change I propose will result in that behaviour. I successfully tested it. 
Relevant [stackoverflow question](http://stackoverflow.com/questions/33799737/bounded-force-graph-with-labels-d3-js). Love this package. Thanks.