### PR TITLE
Actually pass linkColour to radialNetwork

### DIFF
--- a/inst/htmlwidgets/diagonalNetwork.js
+++ b/inst/htmlwidgets/diagonalNetwork.js
@@ -78,7 +78,7 @@ HTMLWidgets.widget({
       .data(links)
       .enter().append("path")
       .style("fill", "none")
-      .style("stroke", "#ccc")
+      .style("stroke", x.options.linkColour)
       .style("opacity", "0.55")
       .style("stroke-width", "1.5px")
       .attr("d", diagonal);

--- a/inst/htmlwidgets/radialNetwork.js
+++ b/inst/htmlwidgets/radialNetwork.js
@@ -83,7 +83,7 @@ HTMLWidgets.widget({
                   .data(links)
                   .enter().append("path")
                   .style("fill", "none")
-                  .style("stroke", "#ccc")
+                  .style("stroke", x.options.linkColour)
                   .style("opacity", "0.55")
                   .style("stroke-width", "1.5px")
                   .attr("d", diagonal);


### PR DESCRIPTION
Hi, I noticed that the `linkColour` parameter is not actually passed to the widget in `radialNetwork` and `diagonalNetwork`, this fixes it.