### PR TITLE
Expose the 'sinksRight' option to sankeyNetwork

### DIFF
--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -39,6 +39,8 @@
 #' @param iterations numeric. Number of iterations in the diagramm layout for 
 #' computation of the depth (y-position) of each node. Note: this runs in the 
 #' browser on the client so don't push it too high.
+#' @param sinksRight boolean. If \code{TRUE}, the last nodes are moved to the 
+#' right border of the plot.
 #'
 #' @examples
 #' \dontrun{
@@ -73,7 +75,7 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     NodeID, NodeGroup = NodeID, LinkGroup = NULL, units = "", 
     colourScale = JS("d3.scale.category20()"), fontSize = 7, 
     fontFamily = NULL, nodeWidth = 15, nodePadding = 10, margin = NULL, 
-    height = NULL, width = NULL, iterations = 32) 
+    height = NULL, width = NULL, iterations = 32, sinksRight = TRUE) 
 {
     # Hack for UI consistency. Think of improving.
     colourScale <- as.character(colourScale)
@@ -122,7 +124,7 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     options = list(NodeID = NodeID, NodeGroup = NodeGroup, LinkGroup = LinkGroup, 
         colourScale = colourScale, fontSize = fontSize, fontFamily = fontFamily, 
         nodeWidth = nodeWidth, nodePadding = nodePadding, units = units, 
-        margin = margin, iterations = iterations)
+        margin = margin, iterations = iterations, sinksRight = sinksRight)
     
     # create widget
     htmlwidgets::createWidget(name = "sankeyNetwork", x = list(links = LinksDF, 

--- a/inst/examples/shiny/server.R
+++ b/inst/examples/shiny/server.R
@@ -31,7 +31,7 @@ shinyServer(function(input, output) {
     Energy <- jsonlite::fromJSON(URL)
     sankeyNetwork(Links = Energy$links, Nodes = Energy$nodes, Source = "source",
                   Target = "target", Value = "value", NodeID = "name",
-                  fontSize = 12, nodeWidth = 30)
+                  fontSize = 12, nodeWidth = 30, sinksRight = input$sinksRight)
   })
 
   output$rt <- renderRadialNetwork({

--- a/inst/examples/shiny/ui.R
+++ b/inst/examples/shiny/ui.R
@@ -14,7 +14,9 @@ shinyUI(fluidPage(
         tabPanel("Simple Network", simpleNetworkOutput("simple")),
         tabPanel("Force Network", forceNetworkOutput("force")),
         tabPanel("Force Network with Legend & Radius", forceNetworkOutput("forceRadius")),
-        tabPanel("Sankey Network", sankeyNetworkOutput("sankey")),
+        tabPanel("Sankey Network", 
+                 checkboxInput("sinksRight", "sinksRight", value = TRUE),
+                 sankeyNetworkOutput("sankey")),
         tabPanel("Reingold-Tilford Tree", radialNetworkOutput("rt"))
       )
     )

--- a/inst/htmlwidgets/lib/sankey.js
+++ b/inst/htmlwidgets/lib/sankey.js
@@ -164,12 +164,15 @@ d3.sankey = function() {
       }
     }
 
-    // Optionally move pure sinks always to the right.
+    // Optionally move pure sinks always to the right, and scale node breadths
     if (sinksRight) {
       moveSinksRight(x);
+      scaleNodeBreadths((size[0] - nodeWidth) / (x - 1));
+    } else {
+      scaleNodeBreadths((size[0] - nodeWidth) / x);
     }
 
-    scaleNodeBreadths((size[0] - nodeWidth) / (x - 1));
+    
   }
 
   // Find a link that breaks a cycle in the graph (if any).

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -184,7 +184,7 @@ HTMLWidgets.widget({
             .text(function(d) { return d.name; })
             .style("font-size", options.fontSize + "px")
             .style("font-family", options.fontFamily ? options.fontFamily : "inherit")
-            .filter(function(d) { return d.x < width / 2; })
+            .filter(function(d) { return d.x < width / 2 || !options.sinksRight; })
             .attr("x", 6 + sankey.nodeWidth())
             .attr("text-anchor", "start");
             

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -96,7 +96,8 @@ HTMLWidgets.widget({
             .size([width, height])
             .nodeWidth(options.nodeWidth)
             .nodePadding(options.nodePadding)
-            .layout(options.iterations);
+            .layout(options.iterations)
+            .sinksRight(options.sinksRight);
 
         // select the svg element and remove existing children
         d3.select(el).select("svg").selectAll("*").remove();

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -96,8 +96,8 @@ HTMLWidgets.widget({
             .size([width, height])
             .nodeWidth(options.nodeWidth)
             .nodePadding(options.nodePadding)
-            .layout(options.iterations)
-            .sinksRight(options.sinksRight);
+            .sinksRight(options.sinksRight)
+            .layout(options.iterations);
 
         // select the svg element and remove existing children
         d3.select(el).select("svg").selectAll("*").remove();

--- a/man/sankeyNetwork.Rd
+++ b/man/sankeyNetwork.Rd
@@ -11,7 +11,8 @@ specifically for Sankey diagrams \url{http://bost.ocks.org/mike/sankey/}.
 sankeyNetwork(Links, Nodes, Source, Target, Value, NodeID, NodeGroup = NodeID,
   LinkGroup = NULL, units = "", colourScale = JS("d3.scale.category20()"),
   fontSize = 7, fontFamily = NULL, nodeWidth = 15, nodePadding = 10,
-  margin = NULL, height = NULL, width = NULL, iterations = 32)
+  margin = NULL, height = NULL, width = NULL, iterations = 32,
+  sinksRight = TRUE)
 }
 \arguments{
 \item{Links}{a data frame object with the links between the nodes. It should
@@ -70,6 +71,9 @@ to accomodate long text labels.}
 \item{iterations}{numeric. Number of iterations in the diagramm layout for 
 computation of the depth (y-position) of each node. Note: this runs in the 
 browser on the client so don't push it too high.}
+
+\item{sinksRight}{boolean. If \code{TRUE}, the last nodes are moved to the 
+right border of the plot.}
 }
 \description{
 Create a D3 JavaScript Sankey diagram


### PR DESCRIPTION
sinksRight is already an argument in sankey.js. If TRUE (the default), the last nodes (sinks) are moved on the right border of the plot, otherwise they stay where they are in the sequence. Sometimes this is more appropriate.

This commit exposes the option to the sankeyNetwork function.