### PR TITLE
Add 'value' support to igraph_to_networkD3

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -189,7 +189,11 @@ igraph_to_networkD3 <- function(g, group, what = 'both') {
     links <- as_data_frame(g, what = 'edges')
     links <- merge(links, temp_nodes, by.x = 'from', by.y = 'name')
     links <- merge(links, temp_nodes, by.x = 'to', by.y = 'name')
-    links <- links[, c('id.x', 'id.y')] %>% setNames(c('source', 'target'))
+    if (ncol(links) == 5) {
+        links <- links[, c('id.x', 'id.y', 'value')] %>% setNames(c('source', 'target', 'value'))
+    else {
+        links <- links[, c('id.x', 'id.y')] %>% setNames(c('source', 'target'))
+    }
 
     # Output requested object
     if (what == 'both') {

--- a/R/utils.R
+++ b/R/utils.R
@@ -191,6 +191,7 @@ igraph_to_networkD3 <- function(g, group, what = 'both') {
     links <- merge(links, temp_nodes, by.x = 'to', by.y = 'name')
     if (ncol(links) == 5) {
         links <- links[, c('id.x', 'id.y', 'value')] %>% setNames(c('source', 'target', 'value'))
+    }
     else {
         links <- links[, c('id.x', 'id.y')] %>% setNames(c('source', 'target'))
     }


### PR DESCRIPTION
The igraph_to_networkD3 function doesn't currently support the 'value' attribute for controlling connection widths/weights. This change includes 'value' in the networkD3 output if the graph has an extra attribute, but works as usual if not.