### PR TITLE
Adding Description to Nodes for sankeyNetwork function

### DIFF
--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -16,6 +16,8 @@
 #' frame for how far away the nodes are from one another.
 #' @param NodeID character string specifying the node IDs in the \code{Nodes}.
 #' data frame. Must be 0-indexed.
+#' @param NodeDesc character string specifying the description of the node ID in the \code{Nodes}.
+#' data frame.
 #' @param NodeGroup character string specifying the node groups in the
 #' \code{Nodes}. Used to color the nodes in the network.
 #' @param LinkGroup character string specifying the groups in the
@@ -50,7 +52,7 @@
 #' 
 #' # Plot
 #' sankeyNetwork(Links = energy$links, Nodes = energy$nodes, Source = 'source',
-#'              Target = 'target', Value = 'value', NodeID = 'name',
+#'              Target = 'target', Value = 'value', NodeID = 'name', NodeDesc = 'name',
 #'              units = 'TWh', fontSize = 12, nodeWidth = 30)
 #'
 #' # Colour links

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -73,7 +73,7 @@
 #' @export
 
 sankeyNetwork <- function(Links, Nodes, Source, Target, Value, 
-    NodeID, NodeDesc = NodeID, NodeGroup = NodeID, LinkGroup = NULL, units = "", 
+    NodeID, NodeDesc, NodeGroup = NodeID, LinkGroup = NULL, units = "", 
     colourScale = JS("d3.scale.category20()"), fontSize = 7, 
     fontFamily = NULL, nodeWidth = 15, nodePadding = 10, margin = NULL, 
     height = NULL, width = NULL, iterations = 32) 

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -71,7 +71,7 @@
 #' @export
 
 sankeyNetwork <- function(Links, Nodes, Source, Target, Value, 
-    NodeID, NodeGroup = NodeID, LinkGroup = NULL, units = "", 
+    NodeID, NodeDesc, NodeGroup = NodeID, LinkGroup = NULL, units = "", 
     colourScale = JS("d3.scale.category20()"), fontSize = 7, 
     fontFamily = NULL, nodeWidth = 15, nodePadding = 10, margin = NULL, 
     height = NULL, width = NULL, iterations = 32) 
@@ -110,7 +110,11 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
         NodeID = 1
     NodesDF <- data.frame(Nodes[, NodeID])
     names(NodesDF) <- c("name")
-    
+    # add node description if specified
+    if (is.character(NodeDesc)) {
+      NodesDF$desc <- Nodes[, NodeDesc]
+    } else {NodesDF$desc <- Nodes[, NodeID]}
+        
     # add node group if specified
     if (is.character(NodeGroup)) {
         NodesDF$group <- Nodes[, NodeGroup]

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -71,7 +71,7 @@
 #' @export
 
 sankeyNetwork <- function(Links, Nodes, Source, Target, Value, 
-    NodeID, NodeDesc, NodeGroup = NodeID, LinkGroup = NULL, units = "", 
+    NodeID, NodeDesc = NodeID, NodeGroup = NodeID, LinkGroup = NULL, units = "", 
     colourScale = JS("d3.scale.category20()"), fontSize = 7, 
     fontFamily = NULL, nodeWidth = 15, nodePadding = 10, margin = NULL, 
     height = NULL, width = NULL, iterations = 32) 

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -171,7 +171,7 @@ HTMLWidgets.widget({
             .style("opacity", 0.9)
             .style("cursor", "move")
             .append("title")
-            .text(function(d) { return d.name + "<br>" + format(d.value) + 
+            .text(function(d) { return d.desc + "<br>" + format(d.value) + 
                 " " + options.units; });
 
         node.append("text")

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -171,7 +171,7 @@ HTMLWidgets.widget({
             .style("opacity", 0.9)
             .style("cursor", "move")
             .append("title")
-            .text(function(d) { return d.desc + "<br>" + format(d.value) + 
+            .text(function(d) { return d.desc + "\n" + format(d.value) + 
                 " " + options.units; });
 
         node.append("text")


### PR DESCRIPTION
Hi Christopher,
I suggest to modify sankeyNetwork function by adding a new field (NodeDesc) into Nodes data frame, which contains description of the node, so that on mouse hover-over the node pop-up message shows not the Node name, but a description for the node. If NodeDesc field is not specified when calling sankeyNetwork function then it is defaulted to NodeID.

This adds flexibility to the information displayed about Network Nodes, while keeping backwards compatibility.

Thank you,
Ivan