### PR TITLE
Adding Description to Nodes for sankeyNetwork function

### DIFF
--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -16,7 +16,7 @@
 #' frame for how far away the nodes are from one another.
 #' @param NodeID character string specifying the node IDs in the \code{Nodes}.
 #' data frame. Must be 0-indexed.
-#' #' @param NodeDesc character string specifying the description of the Node Id 
+#' @param NodeDesc character string specifying the description of each Node ID 
 #' in the \code{Nodes} data frame. If not specified defaults to NodeID.
 #' @param NodeGroup character string specifying the node groups in the
 #' \code{Nodes}. Used to color the nodes in the network.

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -16,6 +16,8 @@
 #' frame for how far away the nodes are from one another.
 #' @param NodeID character string specifying the node IDs in the \code{Nodes}.
 #' data frame. Must be 0-indexed.
+#' #' @param NodeDesc character string specifying the description of the Node Id 
+#' in the \code{Nodes} data frame. If not specified defaults to NodeID.
 #' @param NodeGroup character string specifying the node groups in the
 #' \code{Nodes}. Used to color the nodes in the network.
 #' @param LinkGroup character string specifying the groups in the
@@ -71,7 +73,7 @@
 #' @export
 
 sankeyNetwork <- function(Links, Nodes, Source, Target, Value, 
-    NodeID, NodeGroup = NodeID, LinkGroup = NULL, units = "", 
+    NodeID, NodeDesc = NULL, NodeGroup = NodeID, LinkGroup = NULL, units = "", 
     colourScale = JS("d3.scale.category20()"), fontSize = 7, 
     fontFamily = NULL, nodeWidth = 15, nodePadding = 10, margin = NULL, 
     height = NULL, width = NULL, iterations = 32) 
@@ -110,6 +112,11 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
         NodeID = 1
     NodesDF <- data.frame(Nodes[, NodeID])
     names(NodesDF) <- c("name")
+    
+    # add node description if specified
+    if (!is.missing(NodeDesc)) {
+      NodesDF$desc <- Nodes[, NodeDesc]
+    } else {NodesDF$desc <- Nodes[, NodeID]}
     
     # add node group if specified
     if (is.character(NodeGroup)) {

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -114,7 +114,7 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     names(NodesDF) <- c("name")
     
     # add node description if specified
-    if (!is.missing(NodeDesc)) {
+    if (!missing(NodeDesc)) {
       NodesDF$desc <- Nodes[, NodeDesc]
     } else {NodesDF$desc <- Nodes[, NodeID]}
     

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -171,7 +171,7 @@ HTMLWidgets.widget({
             .style("opacity", 0.9)
             .style("cursor", "move")
             .append("title")
-            .text(function(d) { return d.name + "<br>" + format(d.value) + 
+            .text(function(d) { return d.desc + "\n" + format(d.value) + 
                 " " + options.units; });
 
         node.append("text")

--- a/man/sankeyNetwork.Rd
+++ b/man/sankeyNetwork.Rd
@@ -8,7 +8,7 @@ D3.js was created by Michael Bostock. See \url{http://d3js.org/} and, more
 specifically for Sankey diagrams \url{http://bost.ocks.org/mike/sankey/}.
 }
 \usage{
-sankeyNetwork(Links, Nodes, Source, Target, Value, NodeID, NodeGroup = NodeID,
+sankeyNetwork(Links, Nodes, Source, Target, Value, NodeID, NodeDesc = NULL, NodeGroup = NodeID,
   LinkGroup = NULL, units = "", colourScale = JS("d3.scale.category20()"),
   fontSize = 7, fontFamily = NULL, nodeWidth = 15, nodePadding = 10,
   margin = NULL, height = NULL, width = NULL, iterations = 32)
@@ -35,6 +35,9 @@ frame for how far away the nodes are from one another.}
 
 \item{NodeID}{character string specifying the node IDs in the \code{Nodes}.
 data frame. Must be 0-indexed.}
+
+\item{NodeDesc}{character string specifying the description of each node ID 
+in the \code{Nodes} data frame. If not specified defaults to NodeID.}
 
 \item{NodeGroup}{character string specifying the node groups in the
 \code{Nodes}. Used to color the nodes in the network.}


### PR DESCRIPTION
Hi Christopher,
I suggest to modify sankeyNetwork function by adding a new field (NodeDesc) into Nodes data frame, which contains description of the node, so that on mouse hover-over the node pop-up message shows not the Node name, but a description for the node. If NodeDesc field is not specified when calling sankeyNetwork function then it is defaulted to NodeID.

This adds flexibility to the information displayed about Network Nodes, while keeping backwards compatibility.

Thank you,
Ivan