### PR TITLE
Fixed bug with 'value' support in igraph_to_networkD3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: D3 JavaScript Network Graphs from R
 Description: Creates 'D3' 'JavaScript' network, tree, dendrogram, and Sankey
     graphs from 'R'.
-Version: 0.2.12
-Date: 2016-06-07
+Version: 0.2.13
+Date: 2016-06-30
 Authors@R: c(
     person("Christopher", "Gandrud", email = "christopher.gandrud@gmail.com",
     role = c("aut", "cre")),

--- a/R/utils.R
+++ b/R/utils.R
@@ -190,7 +190,7 @@ igraph_to_networkD3 <- function(g, group, what = 'both') {
     links <- merge(links, temp_nodes, by.x = 'from', by.y = 'name')
     links <- merge(links, temp_nodes, by.x = 'to', by.y = 'name')
     if (ncol(links) == 5) {
-        links <- links[, c('id.x', 'id.y', 'value')] %>% 
+        links <- links[, c('id.x', 'id.y', 'weight')] %>% 
                       setNames(c('source', 'target', 'value'))
     }
     else {


### PR DESCRIPTION
[Attached](https://github.com/christophergandrud/networkD3/files/340557/minimal_example.tar.gz) is a minimal R example. Please let me know if something is not clear.

I am not entirely clear on the original intended "value" support in igraph_to_networkD3. The fix relabels the "weight" column containing edge weights as "value".

Best,
Maurits