### PR TITLE
add resize to sankeyNetwork for flexdashboard

### DIFF
--- a/inst/examples/.gitignore
+++ b/inst/examples/.gitignore
@@ -1,1 +1,2 @@
 examples.html
+flex_dashboard_sankey.html

--- a/inst/examples/flex_dashboard_sankey.Rmd
+++ b/inst/examples/flex_dashboard_sankey.Rmd
@@ -1,0 +1,40 @@
+---
+title: "sankey in flex dashboard"
+author: "Kenton Russell"
+output: 
+  flexdashboard::flex_dashboard
+---
+
+**See [StackOverflow](http://stackoverflow.com/questions/38019858/multi-page-flex-dashboard-plots-with-incorrect-zoom-levels/38127540#38127540)**
+
+Page 1
+==================
+```{r setup, include=FALSE}
+library(flexdashboard)
+library(networkD3)
+
+URL <- paste0(
+        "https://cdn.rawgit.com/christophergandrud/networkD3/",
+        "master/JSONdata/energy.json")
+Energy <- jsonlite::fromJSON(URL)
+# Plot
+s1<-sankeyNetwork(Links = Energy$links, Nodes = Energy$nodes, Source = "source",
+             Target = "target", Value = "value", NodeID = "name",
+             units = "TWh", fontSize = 12, nodeWidth = 30)
+```
+
+### Page 1
+
+```{r}
+  s1
+
+```
+
+Page 2
+==================
+
+### Page 2
+
+```{r}
+s1
+```

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -24,6 +24,13 @@ HTMLWidgets.widget({
 
         this.renderValue(el, instance.x, instance);
         */
+        debugger;
+        // with flexdashboard and slides
+        //   sankey might be hidden so height and width 0
+        //   in this instance re-render on resize
+        if( d3.min(instance.sankey.size()) <= 0 ) {
+          this.renderValue(el, instance.x, instance);
+        }
     },
 
     renderValue: function(el, x, instance) {
@@ -100,6 +107,8 @@ HTMLWidgets.widget({
 
         // select the svg element and remove existing children
         d3.select(el).select("svg").selectAll("*").remove();
+        // remove any previously set viewBox attribute
+        d3.select(el).select("svg").attr("viewBox", null);
         // append g for our container to transform by margin
         var svg = d3.select(el).select("svg").append("g")
             .attr("transform", "translate(" + margin.left + "," + margin.top + ")");;


### PR DESCRIPTION
`flexdashboard`, `tabset`, and other html frameworks hide elements which causes an `htmlwidget` using `getBoundingClientRect()` for sizing to get a `height` and `width` of 0.  When the htmlwidget changes from hidden to shown, an `htmlwidget` requires `resize` to re-render using the now know `height` and `width`.  Unfortunately, this will often re-render already drawn `htmlwidgets` losing any previous interaction or state.  This pull attempts to partially address the problem by adding a `resize` method, which will only re-render if it detects a 0 or negative `height` or `width`.  We will get some errors in the JavaScript console, since the first render is not conditional on height or width `>0`, but handling this will require a more significant rewrite and testing.  Also, for now we will stick with `viewBox` as our primary resize mechanism to preserve state and interaction in a non-flexdashboard-type context.

As an example, I added the reproducible code from the StackOverflow post https://github.com/timelyportfolio/networkD3/blob/d1e147a52228373e6eeeaa017cb707d81053a7c6/inst/examples/flex_dashboard_sankey.Rmd.

Here is the [live result](http://bl.ocks.org/timelyportfolio/4b01bbdea890dea55aca41ad1d2dd950).

#122 and [StackOverflow](http://stackoverflow.com/questions/38019858/multi-page-flex-dashboard-plots-with-incorrect-zoom-levels/38127540#38127540)