### PR TITLE
Sankey highlight entire link path

### DIFF
--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -73,8 +73,8 @@
 #' @export
 
 sankeyNetwork <- function(Links, Nodes, Source, Target, Value, 
-    NodeID, NodeGroup = NodeID, LinkGroup = NULL, units = "", 
-    colourScale = JS("d3.scale.category20()"), fontSize = 7, 
+    NodeID, NodeGroup = NodeID, LinkGroup = NULL, LinkName = NULL,
+    units = "", colourScale = JS("d3.scale.category20()"), fontSize = 7, 
     fontFamily = NULL, nodeWidth = 15, nodePadding = 10, margin = NULL, 
     height = NULL, width = NULL, iterations = 32, sinksRight = TRUE) 
 {
@@ -124,6 +124,11 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     
     if (is.character(LinkGroup)) {
         LinksDF$group <- Links[, LinkGroup]
+    }
+        
+     # specify an optional name for an individual link
+    if (is.character(LinkName)) {
+        LinksDF$linkName <- Links[, LinkName]
     }
     
     margin <- margin_handler(margin)

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -131,13 +131,26 @@ HTMLWidgets.widget({
             .style("stroke", color_link)
             .style("stroke-opacity", opacity_link)
             .sort(function(a, b) { return b.dy - a.dy; })
+            .attr("link-name", function(d){
+              return d.linkName;
+             })
             .on("mouseover", function(d) {
-                d3.select(this)
+              if (d.linkName) {
+                ds.selectAll("[link-name=" + d.linkName + "]")
                 .style("stroke-opacity", function(d){return opacity_link(d) + 0.3});
+              } else {
+                  d3.select(this)
+                  .style("stroke-opacity", function(d){return opacity_link(d) + 0.3});
+              }
             })
             .on("mouseout", function(d) {
+              if (d.linkName) {
+                ds.selectAll("[link-name=" + d.linkName + "]")
+                .style("stroke-opacity", function(d){return opacity_link(d) + 0.3});
+              } else {
                 d3.select(this)
                 .style("stroke-opacity", opacity_link);
+              }
             });
 
         // add backwards class to cycles
@@ -170,7 +183,7 @@ HTMLWidgets.widget({
         // note: u2192 is right-arrow
         link.append("title")
             .text(function(d) { return d.source.name + " \u2192 " + d.target.name +
-                "\n" + format(d.value) + " " + options.units; });
+                "\n" + format(d.value) + " " + options.units + " (" + d.linkName + ")"; });
 
         node.append("rect")
             .attr("height", function(d) { return d.dy; })

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -182,8 +182,15 @@ HTMLWidgets.widget({
             });
         // note: u2192 is right-arrow
         link.append("title")
-            .text(function(d) { return d.source.name + " \u2192 " + d.target.name +
-                "\n" + format(d.value) + " " + options.units + " (" + d.linkName + ")"; });
+            .text(function(d) {
+              if (d.linkName) {
+                return d.source.name + " \u2192 " + d.target.name +
+                "\n" + format(d.value) + " " + options.units + " (" + d.linkName + ")";
+              } else {
+                return d.source.name + " \u2192 " + d.target.name +
+                "\n" + format(d.value) + " " + options.units;
+              }
+            });
 
         node.append("rect")
             .attr("height", function(d) { return d.dy; })

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -136,17 +136,17 @@ HTMLWidgets.widget({
              })
             .on("mouseover", function(d) {
               if (d.linkName) {
-                ds.selectAll("[link-name=" + d.linkName + "]")
+                d3.selectAll("[link-name=" + d.linkName + "]")
                 .style("stroke-opacity", function(d){return opacity_link(d) + 0.3});
               } else {
-                  d3.select(this)
-                  .style("stroke-opacity", function(d){return opacity_link(d) + 0.3});
+                d3.select(this)
+                .style("stroke-opacity", function(d){return opacity_link(d) + 0.3});
               }
             })
             .on("mouseout", function(d) {
               if (d.linkName) {
-                ds.selectAll("[link-name=" + d.linkName + "]")
-                .style("stroke-opacity", function(d){return opacity_link(d) + 0.3});
+                d3.selectAll("[link-name=" + d.linkName + "]")
+                .style("stroke-opacity", opacity_link);
               } else {
                 d3.select(this)
                 .style("stroke-opacity", opacity_link);


### PR DESCRIPTION
I found this functionality--on mouseover, highlight a link's entire path when it runs through multiple nodes--useful when I needed to trace a number of individual links/variables through an entire network.