### PR TITLE
titles in <pre> for better browser compatibility

### DIFF
--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -165,8 +165,10 @@ HTMLWidgets.widget({
             });
         // note: u2192 is right-arrow
         link.append("title")
-            .text(function(d) { return d.source.name + " \u2192 " + d.target.name +
-                "\n" + format(d.value) + " " + options.units; });
+            .append("foreignObject")
+            .append("xhtml:body")
+            .html(function(d) { return "<pre>" + d.source.name + " \u2192 " + d.target.name +
+                "\n" + format(d.value) + " " + options.units + "</pre>"; });
 
         node.append("rect")
             .attr("height", function(d) { return d.dy; })
@@ -177,8 +179,10 @@ HTMLWidgets.widget({
             .style("opacity", 0.9)
             .style("cursor", "move")
             .append("title")
-            .text(function(d) { return d.name + "<br>" + format(d.value) + 
-                " " + options.units; });
+            .append("foreignObject")
+            .append("xhtml:body")
+            .html(function(d) { return "<pre>" + d.name + "<br>" + format(d.value) + 
+                " " + options.units + "</pre>"; });
 
         node.append("text")
             .attr("x", -6)


### PR DESCRIPTION
This PR makes the sankey plot put its multi-line title/tooltip strings inside a `<pre>` tag, which seems (after some experimentation by @cjyetman) to have the broadest browser compatibility (i.e. it actually works in IE11/Windows7, and doesn't break functionality in recent versions of Chrome, Firefox, and Safari)

This PR resolves issue #175 and #146, and supersedes PR #152, as well as address one of the issues with PR #130