### PR TITLE
Sankey: explicit <xhtml:pre> instead of <xhtml:body> for bootstrap-datepicker compatibility

### DIFF
--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -165,10 +165,9 @@ HTMLWidgets.widget({
             });
         // note: u2192 is right-arrow
         link.append("title")
-            .append("foreignObject")
-            .append("xhtml:body")
-            .html(function(d) { return "<pre>" + d.source.name + " \u2192 " + d.target.name +
-                "\n" + format(d.value) + " " + options.units + "</pre>"; });
+            .append("xhtml:pre")
+            .text(function(d) { return d.source.name + " \u2192 " + d.target.name +
+                "\n" + format(d.value) + " " + options.units; });
 
         node.append("rect")
             .attr("height", function(d) { return d.dy; })
@@ -179,10 +178,9 @@ HTMLWidgets.widget({
             .style("opacity", 0.9)
             .style("cursor", "move")
             .append("title")
-            .append("foreignObject")
-            .append("xhtml:body")
-            .html(function(d) { return "<pre>" + d.name + "<br>" + format(d.value) + 
-                " " + options.units + "</pre>"; });
+            .append("xhtml:pre")
+            .text(function(d) { return d.name + "\n" + format(d.value) + 
+                " " + options.units; });
 
         node.append("text")
             .attr("x", -6)


### PR DESCRIPTION
Removes the necessity of declaring a new namespace for each <title> using the <xhtml:body> tag, since there is only one <xhtml:pre> for each title in any case.

Working on Chrome 60.0.3112.113, FF 55.0.3, Safari 10.1.2, IE11.

Fixes #214 