### PR TITLE
Sankey tooltip: if link value passed as string, don't round tooltip to integer

### DIFF
--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -94,7 +94,10 @@ HTMLWidgets.widget({
 
 
         var formatNumber = d3.format(",.0f"),
-        format = function(d) { return formatNumber(d); }
+        format = function(d) { 
+            if (typeof d === "string") return d;
+            return formatNumber(d); 
+        }
 
         // create d3 sankey layout
         sankey


### PR DESCRIPTION
Fixes #147, numeric values are currently rounded to integer in the tooltips.

A way to fix trying not to completely break backwards compatibility is to check whether the provided values are strings and in that case avoid formatting them.

Simple example:

```
library(networkD3)
links <- data.frame(source=c(0, 0), target=c(1, 2), value=c(0.5, 0.95))
nodes <- data.frame(names = c("first", "second", "third"))
sankeyNetwork(Links = links, Nodes = nodes, 
              Source = 'source', Target = 'target', Value = 'value')
```
<img width="417" alt="screen shot 2017-09-28 at 16 16 22" src="https://user-images.githubusercontent.com/15089539/30971756-2b01134c-a469-11e7-9d4b-78abbf2349c2.png">


```
links$value <- as.character(links$value)
sankeyNetwork(Links = links, Nodes = nodes,
              Source = 'source', Target = 'target', Value = 'value')
```
<img width="413" alt="screen shot 2017-09-28 at 16 16 36" src="https://user-images.githubusercontent.com/15089539/30971769-3338814e-a469-11e7-88c1-2cae96c3fe65.png">
