### PR TITLE
location.href in url(...)

### DIFF
--- a/inst/htmlwidgets/forceNetwork.js
+++ b/inst/htmlwidgets/forceNetwork.js
@@ -136,7 +136,7 @@ HTMLWidgets.widget({
       });
 
     if (options.arrows) {
-      link.style("marker-end",  function(d) { return "url(#arrow-" + d.colour + ")"; });
+      link.style("marker-end",  function(d) { return "url(" + location.href + "#arrow-" + d.colour + ")"; });
 
       var linkColoursArr = d3.nest().key(function(d) { return d.colour; }).entries(links);
 


### PR DESCRIPTION
Arrows do not work in WebKit (iPad, Safari) due to treatment of `url(...)` in WebKit.  For this issue (and possible fixes), please see https://stackoverflow.com/a/29984481

I made one small change (added `location.href`) and now it seems to behave as expected.


Here is the sample Shiny app I used for testing. I have deployed it at https://numeract.shinyapps.io/test/ (it includes the suggested change).

```R
require(shiny)
require(networkD3)

shiny::shinyApp(
    ui = bootstrapPage(
        networkD3::forceNetworkOutput(outputId = 'plot3')
    ),
    server = function(input, output) {
        
        data(MisLinks)
        data(MisNodes)
        
        output$plot3 <- networkD3::renderForceNetwork({
            forceNetwork(Links = MisLinks, Nodes = MisNodes, Source = "source",
                         Target = "target", Value = "value", NodeID = "name",
                             Group = "group", opacity = 1, arrows = TRUE)
            
        })
    }
)

```