### PR TITLE
Fix use of `check_zero()` in `forceNetwork()` and `sankeyNetwork()`

### DIFF
--- a/R/forceNetwork.R
+++ b/R/forceNetwork.R
@@ -171,9 +171,6 @@ forceNetwork <- function(Links,
                          opacityNoHover = 0,
                          clickAction = NULL)
 {
-    # Check if data is zero indexed
-    check_zero(Links[, Source], Links[, Target])
-
     # If tbl_df convert to plain data.frame
     Links <- tbl_df_strip(Links)
     Nodes <- tbl_df_strip(Nodes)
@@ -190,6 +187,14 @@ forceNetwork <- function(Links,
     if (!is.data.frame(Nodes)) {
             stop("Nodes must be a data frame class object.")
     }
+    
+    # if Source or Target are missing assume Source is the first
+    # column Target is the second column
+    if (missing(Source))
+        Source = 1
+    if (missing(Target))
+        Target = 2
+    
     if (missing(Value)) {
             LinksDF <- data.frame(Links[, Source], Links[, Target])
             names(LinksDF) <- c("source", "target")
@@ -207,6 +212,9 @@ forceNetwork <- function(Links,
             names(NodesDF) <- c("name", "group")
             nodesize = FALSE
     }
+    
+    # Check if data is zero indexed
+    check_zero(Links[, Source], Links[, Target])
 
     LinksDF <- data.frame(LinksDF, colour = linkColour)
     LinksDF$colour = as.character(LinksDF$colour)

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -78,9 +78,6 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     fontFamily = NULL, nodeWidth = 15, nodePadding = 10, margin = NULL,
     height = NULL, width = NULL, iterations = 32, sinksRight = TRUE)
 {
-    # Check if data is zero indexed
-    check_zero(Links[, Source], Links[, Target])
-
     # Hack for UI consistency. Think of improving.
     colourScale <- as.character(colourScale)
 
@@ -95,6 +92,7 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     if (!is.data.frame(Nodes)) {
         stop("Nodes must be a data frame class object.")
     }
+    
     # if Source or Target are missing assume Source is the first
     # column Target is the second column
     if (missing(Source))
@@ -110,6 +108,9 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
             Links[, Value])
         names(LinksDF) <- c("source", "target", "value")
     }
+    
+    # Check if data is zero indexed
+    check_zero(Links[, Source], Links[, Target])
 
     # if NodeID is missing assume NodeID is the first column
     if (missing(NodeID))


### PR DESCRIPTION
Fixes #281 

Calling `check_zero()` too early in the function resulted in a bug where 1-indexed input would not be detected if either:

* `Links` was not a `data.frame`
* `Source` or `Target` were missing

Moving `check_zero()` further down the functions and adding missing input checks for `forceNetwork()` fixes the issue.