### PR TITLE
Directed arrows for Sankey Network

### DIFF
--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -41,6 +41,7 @@
 #' browser on the client so don't push it too high.
 #' @param sinksRight boolean. If \code{TRUE}, the last nodes are moved to the
 #' right border of the plot.
+#' @param arrowheads logical value to enable directional link arrows.
 #'
 #' @examples
 #' \dontrun{
@@ -76,7 +77,8 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     NodeID, NodeGroup = NodeID, LinkGroup = NULL, units = "",
     colourScale = JS("d3.scaleOrdinal(d3.schemeCategory20);"), fontSize = 7,
     fontFamily = NULL, nodeWidth = 15, nodePadding = 10, margin = NULL,
-    height = NULL, width = NULL, iterations = 32, sinksRight = TRUE)
+    height = NULL, width = NULL, iterations = 32, sinksRight = TRUE,
+    arrowheads=FALSE)
 {
     # Check if data is zero indexed
     check_zero(Links[, Source], Links[, Target])
@@ -132,7 +134,8 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     options = list(NodeID = NodeID, NodeGroup = NodeGroup, LinkGroup = LinkGroup,
         colourScale = colourScale, fontSize = fontSize, fontFamily = fontFamily,
         nodeWidth = nodeWidth, nodePadding = nodePadding, units = units,
-        margin = margin, iterations = iterations, sinksRight = sinksRight)
+        margin = margin, iterations = iterations, sinksRight = sinksRight,
+        arrowheads = arrowheads)
 
     # create widget
     htmlwidgets::createWidget(name = "sankeyNetwork", x = list(links = LinksDF,

--- a/R/sankeyNetwork.R
+++ b/R/sankeyNetwork.R
@@ -41,7 +41,7 @@
 #' browser on the client so don't push it too high.
 #' @param sinksRight boolean. If \code{TRUE}, the last nodes are moved to the
 #' right border of the plot.
-#' @param arrowheads logical value to enable directional link arrows.
+#' @param arrows logical value to enable directional link arrows.
 #'
 #' @examples
 #' \dontrun{
@@ -78,7 +78,7 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
     colourScale = JS("d3.scaleOrdinal(d3.schemeCategory20);"), fontSize = 7,
     fontFamily = NULL, nodeWidth = 15, nodePadding = 10, margin = NULL,
     height = NULL, width = NULL, iterations = 32, sinksRight = TRUE,
-    arrowheads=FALSE)
+    arrows=FALSE)
 {
     # Check if data is zero indexed
     check_zero(Links[, Source], Links[, Target])
@@ -135,7 +135,7 @@ sankeyNetwork <- function(Links, Nodes, Source, Target, Value,
         colourScale = colourScale, fontSize = fontSize, fontFamily = fontFamily,
         nodeWidth = nodeWidth, nodePadding = nodePadding, units = units,
         margin = margin, iterations = iterations, sinksRight = sinksRight,
-        arrowheads = arrowheads)
+        arrows = arrows)
 
     # create widget
     htmlwidgets::createWidget(name = "sankeyNetwork", x = list(links = LinksDF,

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -140,6 +140,27 @@ HTMLWidgets.widget({
                 .style("stroke-opacity", opacity_link);
             });
 
+	if (options.arrowheads) {
+      	link.style("marker-end",  function(d) { return "url(#arrow-" + d.colour + ")"; });
+
+      var linkColoursArr = d3.nest().key(function(d) { return d.colour; }).entries(links);
+
+      svg.append("defs").selectAll("marker")
+          .data(linkColoursArr)
+          .enter().append("marker")
+            .attr("id", function(d) { return "arrow-" + d.key; })
+            .attr("viewBox", "0, -5, 10, 10")
+            .attr("refX", 10)
+            .attr("markerWidth", 1)
+            .attr("markerHeight", 1)
+            .attr("orient", "auto")
+            .style("fill", "context-fill")
+            .style("fill", function(d) { return d.key; })
+            .style("opacity", 0.5)
+          .append("path")
+            .attr("d", "M0,-5 L10,0 L0,5");
+    }
+
         // add backwards class to cycles
         link.classed('backwards', function (d) { return d.target.x < d.source.x; });
 

--- a/inst/htmlwidgets/sankeyNetwork.js
+++ b/inst/htmlwidgets/sankeyNetwork.js
@@ -121,7 +121,7 @@ HTMLWidgets.widget({
         var path = sankey.link();
 
         // draw links
-        var link = svg.selectAll(".link")
+        var link = svg.selectAll(".node")
             .data(links)
             .enter().append("path")
             .attr("class", "link")
@@ -140,26 +140,7 @@ HTMLWidgets.widget({
                 .style("stroke-opacity", opacity_link);
             });
 
-	if (options.arrowheads) {
-      	link.style("marker-end",  function(d) { return "url(#arrow-" + d.colour + ")"; });
-
-      var linkColoursArr = d3.nest().key(function(d) { return d.colour; }).entries(links);
-
-      svg.append("defs").selectAll("marker")
-          .data(linkColoursArr)
-          .enter().append("marker")
-            .attr("id", function(d) { return "arrow-" + d.key; })
-            .attr("viewBox", "0, -5, 10, 10")
-            .attr("refX", 10)
-            .attr("markerWidth", 1)
-            .attr("markerHeight", 1)
-            .attr("orient", "auto")
-            .style("fill", "context-fill")
-            .style("fill", function(d) { return d.key; })
-            .style("opacity", 0.5)
-          .append("path")
-            .attr("d", "M0,-5 L10,0 L0,5");
-    }
+	
 
         // add backwards class to cycles
         link.classed('backwards', function (d) { return d.target.x < d.source.x; });
@@ -193,6 +174,30 @@ HTMLWidgets.widget({
             .append("xhtml:body")
             .html(function(d) { return "<pre>" + d.source.name + " \u2192 " + d.target.name +
                 "\n" + format(d.value) + " " + options.units + "</pre>"; });
+
+	if (options.arrows) {
+      	link.style("marker-end",  function(d) { return "url(#arrow-" + d.key + ")"; });
+
+      var linkColoursArr = d3.nest().key(function(d) { return d.colour; }).entries(links);
+
+      node.selectAll(".link")
+          .data(linkColoursArr)
+          .enter().append("marker")
+            .attr("id", function(d) { return "arrow-" + d.key; })
+            .attr("viewBox", "0, -5, 10, 10")
+            .attr("refX", 10)
+            .attr("refY", 0)
+            .attr("preserveAspectRatio", "xMaxYMin meet")
+            .attr("Width", sankey.nodeWidth())
+            .attr("markerHeight", 1)
+            .attr("orient", "auto-start-reverse")
+	    //.attr("transform", "skewY(40)")
+            .style("fill", "context-fill")
+            //.style("fill", function(d) { return d.key; })
+            .style("opacity", 0.5)
+          .append("path")
+            .attr("d", "M0,-5 L10,0 L0,5");
+    }		
 
         node.append("rect")
             .attr("height", function(d) { return d.dy; })


### PR DESCRIPTION
Aims to resolve #277. 
The Sankey network now includes the arrows = T option (F by default) to add directed arrows within the link bar between nodes with opacity darker than the link bar to indicate the connections. 
As of now the arrowhead is not placed at the end of the link bar, and some angles do not work perfectly. I may need to work on this further but it is a step towards a full solution.